### PR TITLE
New "Maze" Game Mode

### DIFF
--- a/maze.go
+++ b/maze.go
@@ -2,11 +2,11 @@ package rules
 
 import ()
 
-type FeastRuleset struct {
+type MazeRuleset struct {
 	StandardRuleset
 }
 
-func (r *FeastRuleset) CreateInitialBoardState(width int32, height int32, snakeIDs []string) (*BoardState, error) {
+func (r *MazeRuleset) CreateInitialBoardState(width int32, height int32, snakeIDs []string) (*BoardState, error) {
 	initialBoardState, err := r.StandardRuleset.CreateInitialBoardState(width, height, snakeIDs)
 	if err != nil {
 		return nil, err
@@ -20,7 +20,7 @@ func (r *FeastRuleset) CreateInitialBoardState(width int32, height int32, snakeI
 	return initialBoardState, nil
 }
 
-func (r *FeastRuleset) CreateNextBoardState(prevState *BoardState, moves []SnakeMove) (*BoardState, error) {
+func (r *MazeRuleset) CreateNextBoardState(prevState *BoardState, moves []SnakeMove) (*BoardState, error) {
 	nextState, err := r.StandardRuleset.CreateNextBoardState(prevState, moves)
 	if err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func (r *FeastRuleset) CreateNextBoardState(prevState *BoardState, moves []Snake
 	return nextState, nil
 }
 
-func (r *FeastRuleset) fillBoardWithFood(b *BoardState) error {
+func (r *MazeRuleset) fillBoardWithFood(b *BoardState) error {
 	unoccupiedPoints := r.getUnoccupiedPoints(b, true)
 	b.Food = append(b.Food, unoccupiedPoints...)
 	return nil

--- a/standard.go
+++ b/standard.go
@@ -548,6 +548,9 @@ func (r *StandardRuleset) getUnoccupiedPoints(b *BoardState, includePossibleMove
 		pointIsOccupied[p.X][p.Y] = true
 	}
 	for _, snake := range b.Snakes {
+		if snake.EliminatedCause != NotEliminated {
+			continue
+		}
 		for i, p := range snake.Body {
 			if _, xExists := pointIsOccupied[p.X]; !xExists {
 				pointIsOccupied[p.X] = map[int32]bool{}


### PR DESCRIPTION
Maze mode addresses the following bugs with the previous "snack-a-tron" challenge mode:
[x] New Ruleset so snakes can know they're in this mode
[x] Turn 0: should fill the entire board with food
[x] Turn 1: spawn food in front of snakes
[x] Eliminated snakes backfill with food immediately