### PR TITLE
Add First High-Level Standard Ruleset JSON Test

### DIFF
--- a/standard_test.go
+++ b/standard_test.go
@@ -6,6 +6,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
 )
 
 func TestStandardRulesetInterface(t *testing.T) {
@@ -2009,5 +2014,35 @@ func TestIsGameOver(t *testing.T) {
 		actual, err := r.IsGameOver(b)
 		require.NoError(t, err)
 		require.Equal(t, test.Expected, actual)
+	}
+}
+
+type JsonGameInput struct {
+	BoardState BoardState
+	Moves      []SnakeMove
+}
+
+func TestFromJson(t *testing.T) {
+	r := StandardRuleset{}
+
+	files, err := filepath.Glob("tests/standard/*.in.json")
+	require.NoError(t, err)
+
+	for _, file := range files {
+		var input JsonGameInput
+		inputData, err := ioutil.ReadFile(file)
+		require.NoError(t, err)
+
+		err2 := json.Unmarshal([]byte(inputData), &input)
+		require.NoError(t, err2)
+
+		var expectedOutput BoardState
+		expectedOutputData, err := ioutil.ReadFile(strings.Replace(file, "in.json", "out.json", 1))
+		err3 := json.Unmarshal([]byte(expectedOutputData), &expectedOutput)
+		require.NoError(t, err3)
+
+		nextState, err4 := r.CreateNextBoardState(&input.BoardState, input.Moves)
+		require.NoError(t, err4)
+		require.Equal(t, *nextState, expectedOutput)
 	}
 }

--- a/tests/standard/1.in.json
+++ b/tests/standard/1.in.json
@@ -1,0 +1,37 @@
+{
+  "BoardState": {
+    "Height": 2,
+    "Width": 2,
+    "Food": [
+      {
+        "X": 1,
+        "Y": 1
+      }
+    ],
+    "Snakes": [
+      {
+        "ID": "one",
+        "Body": [
+          {
+            "X": 0,
+            "Y": 0
+          },
+          {
+            "X": 0,
+            "Y": 0
+          },
+          {
+            "X": 0,
+            "Y": 0
+          }
+        ],
+        "Health": 100,
+        "EliminatedCause": "",
+        "EliminatedBy": ""
+      }
+    ]
+  },
+  "Moves": [
+    { "ID": "one", "move": "up"}
+  ]
+}

--- a/tests/standard/1.out.json
+++ b/tests/standard/1.out.json
@@ -1,0 +1,32 @@
+{
+  "Height": 2,
+  "Width": 2,
+  "Food": [
+    {
+      "X": 1,
+      "Y": 1
+    }
+  ],
+  "Snakes": [
+    {
+      "ID": "one",
+      "Body": [
+        {
+          "X": 0,
+          "Y": 1
+        },
+        {
+          "X": 0,
+          "Y": 0
+        },
+        {
+          "X": 0,
+          "Y": 0
+        }
+      ],
+      "Health": 99,
+      "EliminatedCause": "",
+      "EliminatedBy": ""
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #3

This creates a basic framework for supporting high level tests where the
input and output are JSON files.

This should allow easier prototyping and building of new game types, as
they can be test driven easily.
The other benefit (and I admit) my primary one, is for sharing the
eventual test suite with other implementations/snakes!

Having the files be JSON is specifically interesting for the second use
case

As for the implementation it's pretty bare bones. It looks in a certain
directory for each file that matches `*.in.json`. This file is a JSON of
a BoardState and an array of SnakeMoves.
We run the standard ruleset using this input and compare it to the
matching `*.out.json` file from the same directory

This is also my first foray into golang, so any and all feedback is
appreciated!