### PR TITLE
Change SnakeResponse.Latency to be a string.

### DIFF
--- a/cli/commands/play.go
+++ b/cli/commands/play.go
@@ -37,7 +37,7 @@ type SnakeResponse struct {
 	Name    string  `json:"name"`
 	Health  int32   `json:"health"`
 	Body    []Coord `json:"body"`
-	Latency int32   `json:"latency"`
+	Latency string  `json:"latency"`
 	Head    Coord   `json:"head"`
 	Length  int32   `json:"length"`
 	Shout   string  `json:"shout"`
@@ -350,7 +350,7 @@ func snakeResponseFromSnake(snake rules.Snake) SnakeResponse {
 		Name:    Battlesnakes[snake.ID].Name,
 		Health:  snake.Health,
 		Body:    coordFromPointArray(snake.Body),
-		Latency: 0,
+		Latency: "0",
 		Head:    coordFromPoint(snake.Body[0]),
 		Length:  int32(len(snake.Body)),
 		Shout:   "",


### PR DESCRIPTION
Currently, the CLI code has Latency as a uint32, which makes good
sense. However, both the [API reference](https://docs.battlesnake.com/references/api#battlesnake) and the production implementation of the battesnake server use a
decimal integer string to represent Latency instead.

It would be best if both implementations could be switched to use a
numerical value, but changing that in prod would be
backwards-incompatible and may break a bunch of people. It's better
for the behaviors to be consistent, and we can probably change the
simulator without bothering too many folks, so here we are.