### PR TITLE
Remove Eliminated Snake from the send payload

### DIFF
--- a/cli/commands/play.go
+++ b/cli/commands/play.go
@@ -393,7 +393,9 @@ func snakeResponseFromSnake(snake rules.Snake) SnakeResponse {
 func buildSnakesResponse(snakes []rules.Snake) []SnakeResponse {
 	var a []SnakeResponse
 	for _, snake := range snakes {
-		a = append(a, snakeResponseFromSnake(snake))
+		if snake.EliminatedCause == rules.NotEliminated {
+			a = append(a, snakeResponseFromSnake(snake))
+		}
 	}
 	return a
 }


### PR DESCRIPTION
Eliminated snakes will no longer be send in  Snakes part of the payload as the production engine..