### PR TITLE
Add turn to BoardState and remove it from RoyaleRuleset

### DIFF
--- a/board.go
+++ b/board.go
@@ -3,6 +3,7 @@ package rules
 import "math/rand"
 
 type BoardState struct {
+	Turn    int32
 	Height  int32
 	Width   int32
 	Food    []Point
@@ -13,6 +14,7 @@ type BoardState struct {
 // NewBoardState returns an empty but fully initialized BoardState
 func NewBoardState(width, height int32) *BoardState {
 	return &BoardState{
+		Turn:    0,
 		Height:  height,
 		Width:   width,
 		Food:    []Point{},
@@ -24,6 +26,7 @@ func NewBoardState(width, height int32) *BoardState {
 // Clone returns a deep copy of prevState that can be safely modified inside Ruleset.CreateNextBoardState
 func (prevState *BoardState) Clone() *BoardState {
 	nextState := &BoardState{
+		Turn:    prevState.Turn,
 		Height:  prevState.Height,
 		Width:   prevState.Width,
 		Food:    append([]Point{}, prevState.Food...),

--- a/cli/commands/play.go
+++ b/cli/commands/play.go
@@ -134,8 +134,7 @@ var run = func(cmd *cobra.Command, args []string) {
 
 	snakes := buildSnakesFromOptions()
 
-	var ruleset rules.Ruleset
-	ruleset = getRuleset(Seed, Turn, snakes)
+	ruleset := getRuleset(Seed, snakes)
 	state := initializeBoardFromArgs(ruleset, snakes)
 	for _, snake := range snakes {
 		Battlesnakes[snake.ID] = snake
@@ -143,8 +142,7 @@ var run = func(cmd *cobra.Command, args []string) {
 
 	for v := false; !v; v, _ = ruleset.IsGameOver(state) {
 		Turn++
-		ruleset = getRuleset(Seed, Turn, snakes)
-		state = createNextBoardState(ruleset, state, snakes)
+		state = createNextBoardState(ruleset, state, snakes, Turn)
 
 		if ViewMap {
 			printMap(state, Turn)
@@ -178,7 +176,7 @@ var run = func(cmd *cobra.Command, args []string) {
 	}
 }
 
-func getRuleset(seed int64, gameTurn int32, snakes []Battlesnake) rules.Ruleset {
+func getRuleset(seed int64, snakes []Battlesnake) rules.Ruleset {
 	var ruleset rules.Ruleset
 	var royale rules.RoyaleRuleset
 
@@ -193,7 +191,6 @@ func getRuleset(seed int64, gameTurn int32, snakes []Battlesnake) rules.Ruleset 
 		royale = rules.RoyaleRuleset{
 			StandardRuleset:   standard,
 			Seed:              seed,
-			Turn:              gameTurn,
 			ShrinkEveryNTurns: 10,
 		}
 		ruleset = &royale
@@ -261,7 +258,7 @@ func initializeBoardFromArgs(ruleset rules.Ruleset, snakes []Battlesnake) *rules
 	return state
 }
 
-func createNextBoardState(ruleset rules.Ruleset, state *rules.BoardState, snakes []Battlesnake) *rules.BoardState {
+func createNextBoardState(ruleset rules.Ruleset, state *rules.BoardState, snakes []Battlesnake, turn int32) *rules.BoardState {
 	var moves []rules.SnakeMove
 	if Sequential {
 		for _, snake := range snakes {
@@ -301,6 +298,9 @@ func createNextBoardState(ruleset rules.Ruleset, state *rules.BoardState, snakes
 		log.Panic("[PANIC]: Error Producing Next Board State")
 		panic(err)
 	}
+
+	state.Turn = turn
+
 	return state
 }
 

--- a/royale.go
+++ b/royale.go
@@ -10,8 +10,6 @@ type RoyaleRuleset struct {
 
 	Seed int64
 
-	// TODO: move Turn into BoardState?
-	Turn              int32
 	ShrinkEveryNTurns int32
 }
 
@@ -28,7 +26,7 @@ func (r *RoyaleRuleset) CreateNextBoardState(prevState *BoardState, moves []Snak
 	}
 
 	// Royale's only job is now to populate the hazards for next turn - StandardRuleset takes care of applying hazard damage.
-	err = r.populateHazards(nextBoardState, r.Turn)
+	err = r.populateHazards(nextBoardState, prevState.Turn+1)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- The BoardState passed into CreateNextBoardState will contain the previous turn, so any ruleset using it will likely need to add 1 to get the current turn
- The BoardState passed into ModifyInitialBoardState will contain turn 0