### PR TITLE
Introduce a CLI option to write the game state to a file in JSONL format

### DIFF
--- a/board.go
+++ b/board.go
@@ -3,12 +3,12 @@ package rules
 import "math/rand"
 
 type BoardState struct {
-	Turn    int32
-	Height  int32
-	Width   int32
-	Food    []Point
-	Snakes  []Snake
-	Hazards []Point
+	Turn    int32   `json:"turn"`
+	Height  int32   `json:"height"`
+	Width   int32   `json:"width"`
+	Food    []Point `json:"food"`
+	Snakes  []Snake `json:"snakes"`
+	Hazards []Point `json:"hazards"`
 }
 
 // NewBoardState returns an empty but fully initialized BoardState

--- a/cli/commands/play.go
+++ b/cli/commands/play.go
@@ -122,6 +122,7 @@ var ViewMap bool
 var Seed int64
 var TurnDelay int32
 var DebugRequests bool
+var OutputFilename string
 
 var FoodSpawnChance int32
 var MinimumFood int32
@@ -150,6 +151,7 @@ func init() {
 	playCmd.Flags().Int64VarP(&Seed, "seed", "r", time.Now().UTC().UnixNano(), "Random Seed")
 	playCmd.Flags().Int32VarP(&TurnDelay, "delay", "d", 0, "Turn Delay in Milliseconds")
 	playCmd.Flags().BoolVar(&DebugRequests, "debug-requests", false, "Log body of all requests sent")
+	playCmd.Flags().StringVarP(&OutputFilename, "output", "o", "game.jsonl", "Filename to output the game to")
 
 	playCmd.Flags().Int32Var(&FoodSpawnChance, "foodSpawnChance", 15, "Percentage chance of spawning a new food every round")
 	playCmd.Flags().Int32Var(&MinimumFood, "minimumFood", 1, "Minimum food to keep on the board every turn")

--- a/constrictor.go
+++ b/constrictor.go
@@ -1,7 +1,7 @@
 package rules
 
 type ConstrictorRuleset struct {
-	StandardRuleset
+	StandardRuleset `json:"standard_ruleset"`
 }
 
 func (r *ConstrictorRuleset) ModifyInitialBoardState(initialBoardState *BoardState) (*BoardState, error) {

--- a/royale.go
+++ b/royale.go
@@ -6,11 +6,11 @@ import (
 )
 
 type RoyaleRuleset struct {
-	StandardRuleset
+	StandardRuleset `json:"standard_ruleset"`
 
-	Seed int64
+	Seed int64 `json:"seed"`
 
-	ShrinkEveryNTurns int32
+	ShrinkEveryNTurns int32 `json:"shrink_every_n_turns"`
 }
 
 func (r *RoyaleRuleset) Name() string { return "royale" }

--- a/ruleset.go
+++ b/ruleset.go
@@ -34,22 +34,22 @@ const (
 )
 
 type Point struct {
-	X int32
-	Y int32
+	X int32 `json:"x"`
+	Y int32 `json:"y"`
 }
 
 type Snake struct {
-	ID               string
-	Body             []Point
-	Health           int32
-	EliminatedCause  string
-	EliminatedOnTurn int32
-	EliminatedBy     string
+	ID               string  `json:"id"`
+	Body             []Point `json:"body"`
+	Health           int32   `json:"health"`
+	EliminatedCause  string  `json:"eliminated_cause"`
+	EliminatedOnTurn int32   `json:"eliminated_on_turn"`
+	EliminatedBy     string  `json:"eliminated_by"`
 }
 
 type SnakeMove struct {
-	ID   string
-	Move string
+	ID   string `json:"id"`
+	Move string `json:"move"`
 }
 
 type Ruleset interface {

--- a/solo.go
+++ b/solo.go
@@ -1,7 +1,7 @@
 package rules
 
 type SoloRuleset struct {
-	StandardRuleset
+	StandardRuleset `json:"standard_ruleset"`
 }
 
 func (r *SoloRuleset) Name() string { return "solo" }

--- a/squad.go
+++ b/squad.go
@@ -7,13 +7,13 @@ import (
 type SquadRuleset struct {
 	StandardRuleset
 
-	SquadMap map[string]string
+	SquadMap map[string]string `json:"squad_map"`
 
 	// These are intentionally designed so that they default to a standard game.
-	AllowBodyCollisions bool
-	SharedElimination   bool
-	SharedHealth        bool
-	SharedLength        bool
+	AllowBodyCollisions bool `json:"allow_body_collisions"`
+	SharedElimination   bool `json:"shared_elimination"`
+	SharedHealth        bool `json:"shared_health"`
+	SharedLength        bool `json:"shared_length"`
 }
 
 const EliminatedBySquad = "squad-eliminated"

--- a/standard.go
+++ b/standard.go
@@ -6,9 +6,9 @@ import (
 )
 
 type StandardRuleset struct {
-	FoodSpawnChance     int32 // [0, 100]
-	MinimumFood         int32
-	HazardDamagePerTurn int32
+	FoodSpawnChance     int32 `json:"food_spawn_chance"` // [0, 100]
+	MinimumFood         int32 `json:"minimum_food"`
+	HazardDamagePerTurn int32 `json:"hazard_damage_per_turn"`
 }
 
 func (r *StandardRuleset) Name() string { return "standard" }
@@ -219,9 +219,9 @@ func (r *StandardRuleset) maybeEliminateSnakes(b *BoardState) error {
 	// Next, look for any collisions. Note we apply collision eliminations
 	// after this check so that snakes can collide with each other and be properly eliminated.
 	type CollisionElimination struct {
-		ID    string
-		Cause string
-		By    string
+		ID    string `json:"id"`
+		Cause string `json:"cause"`
+		By    string `json:"by"`
 	}
 	collisionEliminations := []CollisionElimination{}
 	for i := 0; i < len(b.Snakes); i++ {


### PR DESCRIPTION
**Background**

We're running local games and wish to be able to parse a game more programmatically. On a basic level, this means easier tracking of the winner/losers, on a more advanced level this will involve replaying the game for AI training purposes.

**The Issue**

The output of the CLI is great for humans, but are difficult to parse programmatically, since it prints the board visually and in the form of Go structs.

**Solution**

I have added a new CLI option `-o file.jsonl` or `--output file.jsonl`. This will write the following to the file `file.jsonl`:
1. Ruleset on the first line
2. Board State on every tick
3. The winner's name, Id and whether it was a draw on the last line

These are being serialised as JSON with one object per line, hence jsonl. If the CLI option is omitted, no file will be generated.
If the file already exists, the data will be appended (this can be changed to overwrite if it makes more sense).

Thank you for Battlesnake and for your consideration :grin: 