### PR TITLE
DEV 559: Refactor CLI and add customizations

### DIFF
--- a/cli/commands/play_test.go
+++ b/cli/commands/play_test.go
@@ -15,8 +15,27 @@ func TestGetIndividualBoardStateForSnake(t *testing.T) {
 		Width:  11,
 		Snakes: []rules.Snake{s1, s2},
 	}
-	snake := Battlesnake{Name: "one", URL: "", ID: "one"}
-	requestBody := getIndividualBoardStateForSnake(state, snake, &rules.StandardRuleset{})
+	s1State := SnakeState{
+		ID:    "one",
+		Name:  "ONE",
+		URL:   "http://example1.com",
+		Head:  "safe",
+		Tail:  "curled",
+		Color: "#123456",
+	}
+	s2State := SnakeState{
+		ID:    "two",
+		Name:  "TWO",
+		URL:   "http://example2.com",
+		Head:  "silly",
+		Tail:  "bolt",
+		Color: "#654321",
+	}
+	snakeStates := map[string]SnakeState{
+		s1State.ID: s1State,
+		s2State.ID: s2State,
+	}
+	requestBody := getIndividualBoardStateForSnake(state, s1State, snakeStates, &rules.StandardRuleset{})
 
 	test.RequireJSONMatchesFixture(t, "testdata/snake_request_body.json", string(requestBody))
 }

--- a/cli/commands/play_test.go
+++ b/cli/commands/play_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/BattlesnakeOfficial/rules"
+	"github.com/BattlesnakeOfficial/rules/test"
 )
 
 func TestGetIndividualBoardStateForSnake(t *testing.T) {
@@ -17,5 +18,5 @@ func TestGetIndividualBoardStateForSnake(t *testing.T) {
 	snake := Battlesnake{Name: "one", URL: "", ID: "one"}
 	requestBody := getIndividualBoardStateForSnake(state, snake, &rules.StandardRuleset{})
 
-	rules.RequireJSONMatchesFixture(t, "testdata/snake_request_body.json", string(requestBody))
+	test.RequireJSONMatchesFixture(t, "testdata/snake_request_body.json", string(requestBody))
 }

--- a/cli/commands/testdata/snake_request_body.json
+++ b/cli/commands/testdata/snake_request_body.json
@@ -1,14 +1,13 @@
 {
   "game": {
     "id": "",
-    "timeout": 500,
     "ruleset": {
       "name": "standard",
       "version": "cli",
       "settings": {
-        "hazardDamagePerTurn": 14,
         "foodSpawnChance": 15,
         "minimumFood": 1,
+        "hazardDamagePerTurn": 14,
         "royale": {
           "shrinkEveryNTurns": 25
         },
@@ -19,18 +18,19 @@
           "sharedLength": true
         }
       }
-    }
+    },
+    "timeout": 500,
+    "source": ""
   },
   "turn": 0,
   "board": {
     "height": 11,
     "width": 11,
-    "food": [],
-    "hazards": [],
     "snakes": [
       {
         "id": "one",
         "name": "",
+        "latency": "0",
         "health": 0,
         "body": [
           {
@@ -38,7 +38,6 @@
             "y": 3
           }
         ],
-        "latency": "0",
         "head": {
           "x": 3,
           "y": 3
@@ -50,6 +49,7 @@
       {
         "id": "two",
         "name": "",
+        "latency": "0",
         "health": 0,
         "body": [
           {
@@ -57,7 +57,6 @@
             "y": 3
           }
         ],
-        "latency": "0",
         "head": {
           "x": 4,
           "y": 3
@@ -66,11 +65,14 @@
         "shout": "",
         "squad": ""
       }
-    ]
+    ],
+    "food": [],
+    "hazards": []
   },
   "you": {
     "id": "one",
     "name": "",
+    "latency": "0",
     "health": 0,
     "body": [
       {
@@ -78,7 +80,6 @@
         "y": 3
       }
     ],
-    "latency": "0",
     "head": {
       "x": 3,
       "y": 3

--- a/cli/commands/testdata/snake_request_body.json
+++ b/cli/commands/testdata/snake_request_body.json
@@ -44,7 +44,12 @@
         },
         "length": 1,
         "shout": "",
-        "squad": ""
+        "squad": "",
+        "customizations": {
+          "color": "",
+          "head": "",
+          "tail": ""
+        }
       },
       {
         "id": "two",
@@ -63,7 +68,12 @@
         },
         "length": 1,
         "shout": "",
-        "squad": ""
+        "squad": "",
+        "customizations": {
+          "color": "",
+          "head": "",
+          "tail": ""
+        }
       }
     ],
     "food": [],
@@ -86,6 +96,11 @@
     },
     "length": 1,
     "shout": "",
-    "squad": ""
+    "squad": "",
+    "customizations": {
+      "color": "",
+      "head": "",
+      "tail": ""
+    }
   }
 }

--- a/cli/commands/testdata/snake_request_body.json
+++ b/cli/commands/testdata/snake_request_body.json
@@ -29,7 +29,7 @@
     "snakes": [
       {
         "id": "one",
-        "name": "",
+        "name": "ONE",
         "latency": "0",
         "health": 0,
         "body": [
@@ -46,14 +46,14 @@
         "shout": "",
         "squad": "",
         "customizations": {
-          "color": "",
-          "head": "",
-          "tail": ""
+          "color": "#123456",
+          "head": "safe",
+          "tail": "curled"
         }
       },
       {
         "id": "two",
-        "name": "",
+        "name": "TWO",
         "latency": "0",
         "health": 0,
         "body": [
@@ -70,9 +70,9 @@
         "shout": "",
         "squad": "",
         "customizations": {
-          "color": "",
-          "head": "",
-          "tail": ""
+          "color": "#654321",
+          "head": "silly",
+          "tail": "bolt"
         }
       }
     ],
@@ -81,7 +81,7 @@
   },
   "you": {
     "id": "one",
-    "name": "",
+    "name": "ONE",
     "latency": "0",
     "health": 0,
     "body": [
@@ -98,9 +98,9 @@
     "shout": "",
     "squad": "",
     "customizations": {
-      "color": "",
-      "head": "",
-      "tail": ""
+      "color": "#123456",
+      "head": "safe",
+      "tail": "curled"
     }
   }
 }

--- a/client/fixtures_test.go
+++ b/client/fixtures_test.go
@@ -1,0 +1,75 @@
+package client
+
+func exampleSnakeRequest() SnakeRequest {
+	return SnakeRequest{
+		Game: Game{
+			ID: "game-id",
+			Ruleset: Ruleset{
+				Name:     "test-ruleset-name",
+				Version:  "cli",
+				Settings: exampleRulesetSettings,
+			},
+			Timeout: 33,
+			Source:  "league",
+		},
+		Turn: 11,
+		Board: Board{
+			Height: 22,
+			Width:  11,
+			Snakes: []Snake{
+				{
+					ID:      "snake-0",
+					Name:    "snake-0-name",
+					Latency: "snake-0-latency",
+					Health:  100,
+					Body:    []Coord{{X: 1, Y: 2}, {X: 1, Y: 3}, {X: 1, Y: 4}},
+					Head:    Coord{X: 1, Y: 2},
+					Length:  3,
+					Shout:   "snake-0-shout",
+					Squad:   "",
+				},
+				{
+					ID:      "snake-1",
+					Name:    "snake-1-name",
+					Latency: "snake-1-latency",
+					Health:  200,
+					Body:    []Coord{{X: 2, Y: 2}, {X: 2, Y: 3}, {X: 2, Y: 4}},
+					Head:    Coord{X: 2, Y: 2},
+					Length:  3,
+					Shout:   "snake-1-shout",
+					Squad:   "snake-1-squad",
+				},
+			},
+			Food:    []Coord{{X: 2, Y: 2}},
+			Hazards: []Coord{{X: 8, Y: 8}, {X: 9, Y: 9}},
+		},
+		You: Snake{
+			ID:      "snake-1",
+			Name:    "snake-1-name",
+			Latency: "snake-1-latency",
+			Health:  200,
+			Body:    []Coord{{X: 2, Y: 2}, {X: 2, Y: 3}, {X: 2, Y: 4}},
+			Head:    Coord{X: 2, Y: 2},
+			Length:  3,
+			Shout:   "snake-1-shout",
+			Squad:   "snake-1-squad",
+		},
+	}
+}
+
+var exampleRulesetSettings = RulesetSettings{
+	FoodSpawnChance:     10,
+	MinimumFood:         20,
+	HazardDamagePerTurn: 30,
+
+	RoyaleSettings: RoyaleSettings{
+		ShrinkEveryNTurns: 40,
+	},
+
+	SquadSettings: SquadSettings{
+		AllowBodyCollisions: true,
+		SharedElimination:   true,
+		SharedHealth:        true,
+		SharedLength:        true,
+	},
+}

--- a/client/fixtures_test.go
+++ b/client/fixtures_test.go
@@ -27,6 +27,11 @@ func exampleSnakeRequest() SnakeRequest {
 					Length:  3,
 					Shout:   "snake-0-shout",
 					Squad:   "",
+					Customizations: Customizations{
+						Head:  "safe",
+						Tail:  "curled",
+						Color: "#123456",
+					},
 				},
 				{
 					ID:      "snake-1",
@@ -38,6 +43,11 @@ func exampleSnakeRequest() SnakeRequest {
 					Length:  3,
 					Shout:   "snake-1-shout",
 					Squad:   "snake-1-squad",
+					Customizations: Customizations{
+						Head:  "silly",
+						Tail:  "bolt",
+						Color: "#654321",
+					},
 				},
 			},
 			Food:    []Coord{{X: 2, Y: 2}},
@@ -53,6 +63,11 @@ func exampleSnakeRequest() SnakeRequest {
 			Length:  3,
 			Shout:   "snake-1-shout",
 			Squad:   "snake-1-squad",
+			Customizations: Customizations{
+				Head:  "silly",
+				Tail:  "bolt",
+				Color: "#654321",
+			},
 		},
 	}
 }

--- a/client/models.go
+++ b/client/models.go
@@ -1,0 +1,100 @@
+package client
+
+import "github.com/BattlesnakeOfficial/rules"
+
+// The top-level message sent in /start, /move, and /end requests
+type SnakeRequest struct {
+	Game  Game  `json:"game"`
+	Turn  int32 `json:"turn"`
+	Board Board `json:"board"`
+	You   Snake `json:"you"`
+}
+
+// Game represents the current game state
+type Game struct {
+	ID      string  `json:"id"`
+	Ruleset Ruleset `json:"ruleset"`
+	Timeout int32   `json:"timeout"`
+	Source  string  `json:"source"`
+}
+
+// Board provides information about the game board
+type Board struct {
+	Height  int32   `json:"height"`
+	Width   int32   `json:"width"`
+	Snakes  []Snake `json:"snakes"`
+	Food    []Coord `json:"food"`
+	Hazards []Coord `json:"hazards"`
+}
+
+// Snake represents information about a snake in the game
+type Snake struct {
+	ID      string  `json:"id"`
+	Name    string  `json:"name"`
+	Latency string  `json:"latency"`
+	Health  int32   `json:"health"`
+	Body    []Coord `json:"body"`
+	Head    Coord   `json:"head"`
+	Length  int32   `json:"length"`
+	Shout   string  `json:"shout"`
+	Squad   string  `json:"squad"`
+}
+
+type Ruleset struct {
+	Name     string          `json:"name"`
+	Version  string          `json:"version"`
+	Settings RulesetSettings `json:"settings"`
+}
+
+type RulesetSettings struct {
+	FoodSpawnChance     int32          `json:"foodSpawnChance"`
+	MinimumFood         int32          `json:"minimumFood"`
+	HazardDamagePerTurn int32          `json:"hazardDamagePerTurn"`
+	RoyaleSettings      RoyaleSettings `json:"royale"`
+	SquadSettings       SquadSettings  `json:"squad"`
+}
+
+type RoyaleSettings struct {
+	ShrinkEveryNTurns int32 `json:"shrinkEveryNTurns"`
+}
+
+type SquadSettings struct {
+	AllowBodyCollisions bool `json:"allowBodyCollisions"`
+	SharedElimination   bool `json:"sharedElimination"`
+	SharedHealth        bool `json:"sharedHealth"`
+	SharedLength        bool `json:"sharedLength"`
+}
+
+// Coord represents a point on the board
+type Coord struct {
+	X int32 `json:"x"`
+	Y int32 `json:"y"`
+}
+
+// The expected format of the response body from a /move request
+type MoveResponse struct {
+	Move  string `json:"move"`
+	Shout string `json:"shout"`
+}
+
+// The expected format of the response body from a GET request to a Battlesnake's index URL
+type SnakeMetadataResponse struct {
+	APIVersion string `json:"apiversion,omitempty"`
+	Author     string `json:"author,omitempty"`
+	Color      string `json:"color,omitempty"`
+	Head       string `json:"head,omitempty"`
+	Tail       string `json:"tail,omitempty"`
+	Version    string `json:"version,omitempty"`
+}
+
+func CoordFromPoint(pt rules.Point) Coord {
+	return Coord{X: pt.X, Y: pt.Y}
+}
+
+func CoordFromPointArray(ptArray []rules.Point) []Coord {
+	a := make([]Coord, 0)
+	for _, pt := range ptArray {
+		a = append(a, CoordFromPoint(pt))
+	}
+	return a
+}

--- a/client/models.go
+++ b/client/models.go
@@ -29,15 +29,22 @@ type Board struct {
 
 // Snake represents information about a snake in the game
 type Snake struct {
-	ID      string  `json:"id"`
-	Name    string  `json:"name"`
-	Latency string  `json:"latency"`
-	Health  int32   `json:"health"`
-	Body    []Coord `json:"body"`
-	Head    Coord   `json:"head"`
-	Length  int32   `json:"length"`
-	Shout   string  `json:"shout"`
-	Squad   string  `json:"squad"`
+	ID             string         `json:"id"`
+	Name           string         `json:"name"`
+	Latency        string         `json:"latency"`
+	Health         int32          `json:"health"`
+	Body           []Coord        `json:"body"`
+	Head           Coord          `json:"head"`
+	Length         int32          `json:"length"`
+	Shout          string         `json:"shout"`
+	Squad          string         `json:"squad"`
+	Customizations Customizations `json:"customizations"`
+}
+
+type Customizations struct {
+	Color string `json:"color"`
+	Head  string `json:"head"`
+	Tail  string `json:"tail"`
 }
 
 type Ruleset struct {

--- a/client/models_test.go
+++ b/client/models_test.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/BattlesnakeOfficial/rules/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildSnakeRequestJSON(t *testing.T) {
+	snakeRequest := exampleSnakeRequest()
+	data, err := json.MarshalIndent(snakeRequest, "", "  ")
+	require.NoError(t, err)
+
+	test.RequireJSONMatchesFixture(t, "testdata/snake_request.json", string(data))
+}
+
+func TestBuildSnakeRequestJSONEmptyRulesetSettings(t *testing.T) {
+	snakeRequest := exampleSnakeRequest()
+	snakeRequest.Game.Ruleset.Settings = RulesetSettings{}
+	data, err := json.MarshalIndent(snakeRequest, "", "  ")
+	require.NoError(t, err)
+
+	test.RequireJSONMatchesFixture(t, "testdata/snake_request_empty_ruleset_settings.json", string(data))
+}

--- a/client/testdata/snake_request.json
+++ b/client/testdata/snake_request.json
@@ -1,0 +1,129 @@
+{
+  "game": {
+    "id": "game-id",
+    "ruleset": {
+      "name": "test-ruleset-name",
+      "version": "cli",
+      "settings": {
+        "foodSpawnChance": 10,
+        "minimumFood": 20,
+        "hazardDamagePerTurn": 30,
+        "royale": {
+          "shrinkEveryNTurns": 40
+        },
+        "squad": {
+          "allowBodyCollisions": true,
+          "sharedElimination": true,
+          "sharedHealth": true,
+          "sharedLength": true
+        }
+      }
+    },
+    "timeout": 33,
+    "source": "league"
+  },
+  "turn": 11,
+  "board": {
+    "height": 22,
+    "width": 11,
+    "snakes": [
+      {
+        "id": "snake-0",
+        "name": "snake-0-name",
+        "latency": "snake-0-latency",
+        "health": 100,
+        "body": [
+          {
+            "x": 1,
+            "y": 2
+          },
+          {
+            "x": 1,
+            "y": 3
+          },
+          {
+            "x": 1,
+            "y": 4
+          }
+        ],
+        "head": {
+          "x": 1,
+          "y": 2
+        },
+        "length": 3,
+        "shout": "snake-0-shout",
+        "squad": ""
+      },
+      {
+        "id": "snake-1",
+        "name": "snake-1-name",
+        "latency": "snake-1-latency",
+        "health": 200,
+        "body": [
+          {
+            "x": 2,
+            "y": 2
+          },
+          {
+            "x": 2,
+            "y": 3
+          },
+          {
+            "x": 2,
+            "y": 4
+          }
+        ],
+        "head": {
+          "x": 2,
+          "y": 2
+        },
+        "length": 3,
+        "shout": "snake-1-shout",
+        "squad": "snake-1-squad"
+      }
+    ],
+    "food": [
+      {
+        "x": 2,
+        "y": 2
+      }
+    ],
+    "hazards": [
+      {
+        "x": 8,
+        "y": 8
+      },
+      {
+        "x": 9,
+        "y": 9
+      }
+    ]
+  },
+  "you": {
+    "id": "snake-1",
+    "name": "snake-1-name",
+    "latency": "snake-1-latency",
+    "health": 200,
+    "body": [
+      {
+        "x": 2,
+        "y": 2
+      },
+      {
+        "x": 2,
+        "y": 3
+      },
+      {
+        "x": 2,
+        "y": 4
+      }
+    ],
+    "head": {
+      "x": 2,
+      "y": 2
+    },
+    "length": 3,
+    "shout": "snake-1-shout",
+    "squad": "snake-1-squad"
+  }
+}

--- a/client/testdata/snake_request.json
+++ b/client/testdata/snake_request.json
@@ -52,7 +52,12 @@
         },
         "length": 3,
         "shout": "snake-0-shout",
-        "squad": ""
+        "squad": "",
+        "customizations": {
+          "color": "#123456",
+          "head": "safe",
+          "tail": "curled"
+        }
       },
       {
         "id": "snake-1",
@@ -79,7 +84,12 @@
         },
         "length": 3,
         "shout": "snake-1-shout",
-        "squad": "snake-1-squad"
+        "squad": "snake-1-squad",
+        "customizations": {
+          "color": "#654321",
+          "head": "silly",
+          "tail": "bolt"
+        }
       }
     ],
     "food": [
@@ -124,6 +134,11 @@
     },
     "length": 3,
     "shout": "snake-1-shout",
-    "squad": "snake-1-squad"
+    "squad": "snake-1-squad",
+    "customizations": {
+      "color": "#654321",
+      "head": "silly",
+      "tail": "bolt"
+    }
   }
 }

--- a/client/testdata/snake_request_empty_ruleset_settings.json
+++ b/client/testdata/snake_request_empty_ruleset_settings.json
@@ -1,0 +1,129 @@
+{
+  "game": {
+    "id": "game-id",
+    "ruleset": {
+      "name": "test-ruleset-name",
+      "version": "cli",
+      "settings": {
+        "foodSpawnChance": 0,
+        "minimumFood": 0,
+        "hazardDamagePerTurn": 0,
+        "royale": {
+          "shrinkEveryNTurns": 0
+        },
+        "squad": {
+          "allowBodyCollisions": false,
+          "sharedElimination": false,
+          "sharedHealth": false,
+          "sharedLength": false
+        }
+      }
+    },
+    "timeout": 33,
+    "source": "league"
+  },
+  "turn": 11,
+  "board": {
+    "height": 22,
+    "width": 11,
+    "snakes": [
+      {
+        "id": "snake-0",
+        "name": "snake-0-name",
+        "latency": "snake-0-latency",
+        "health": 100,
+        "body": [
+          {
+            "x": 1,
+            "y": 2
+          },
+          {
+            "x": 1,
+            "y": 3
+          },
+          {
+            "x": 1,
+            "y": 4
+          }
+        ],
+        "head": {
+          "x": 1,
+          "y": 2
+        },
+        "length": 3,
+        "shout": "snake-0-shout",
+        "squad": ""
+      },
+      {
+        "id": "snake-1",
+        "name": "snake-1-name",
+        "latency": "snake-1-latency",
+        "health": 200,
+        "body": [
+          {
+            "x": 2,
+            "y": 2
+          },
+          {
+            "x": 2,
+            "y": 3
+          },
+          {
+            "x": 2,
+            "y": 4
+          }
+        ],
+        "head": {
+          "x": 2,
+          "y": 2
+        },
+        "length": 3,
+        "shout": "snake-1-shout",
+        "squad": "snake-1-squad"
+      }
+    ],
+    "food": [
+      {
+        "x": 2,
+        "y": 2
+      }
+    ],
+    "hazards": [
+      {
+        "x": 8,
+        "y": 8
+      },
+      {
+        "x": 9,
+        "y": 9
+      }
+    ]
+  },
+  "you": {
+    "id": "snake-1",
+    "name": "snake-1-name",
+    "latency": "snake-1-latency",
+    "health": 200,
+    "body": [
+      {
+        "x": 2,
+        "y": 2
+      },
+      {
+        "x": 2,
+        "y": 3
+      },
+      {
+        "x": 2,
+        "y": 4
+      }
+    ],
+    "head": {
+      "x": 2,
+      "y": 2
+    },
+    "length": 3,
+    "shout": "snake-1-shout",
+    "squad": "snake-1-squad"
+  }
+}

--- a/client/testdata/snake_request_empty_ruleset_settings.json
+++ b/client/testdata/snake_request_empty_ruleset_settings.json
@@ -52,7 +52,12 @@
         },
         "length": 3,
         "shout": "snake-0-shout",
-        "squad": ""
+        "squad": "",
+        "customizations": {
+          "color": "#123456",
+          "head": "safe",
+          "tail": "curled"
+        }
       },
       {
         "id": "snake-1",
@@ -79,7 +84,12 @@
         },
         "length": 3,
         "shout": "snake-1-shout",
-        "squad": "snake-1-squad"
+        "squad": "snake-1-squad",
+        "customizations": {
+          "color": "#654321",
+          "head": "silly",
+          "tail": "bolt"
+        }
       }
     ],
     "food": [
@@ -124,6 +134,11 @@
     },
     "length": 3,
     "shout": "snake-1-shout",
-    "squad": "snake-1-squad"
+    "squad": "snake-1-squad",
+    "customizations": {
+      "color": "#654321",
+      "head": "silly",
+      "tail": "bolt"
+    }
   }
 }

--- a/ruleset_test.go
+++ b/ruleset_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	// included to allow using -update-fixtures for every package without errors
+	_ "github.com/BattlesnakeOfficial/rules/test"
 )
 
 func TestRulesetError(t *testing.T) {

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -1,10 +1,11 @@
-package rules
+package test
 
 import (
 	"bytes"
 	"encoding/json"
 	"flag"
 	"io/ioutil"
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,6 +27,8 @@ func RequireJSONMatchesFixture(t *testing.T, filename string, actual string) {
 		require.NoError(t, err, "Failed to indent JSON")
 		err = ioutil.WriteFile(filename, indented.Bytes(), 0644)
 		require.NoError(t, err, "Failed to update fixture", filename)
+
+		log.Printf("Updating fixture file %#v", filename)
 	}
 
 	expectedData, err := ioutil.ReadFile(filename)


### PR DESCRIPTION
The main idea here is to pull the current types that define the Battlesnake API into this repo, where they can be referenced by the main engine. That way, any changes in the API will automatically be referenced here. Included in those types is the new `customizations` fields on each snake that pass the head, tail, and color.

To actually use that in the CLI in a testable way, I had to refactor things a bit - some of the global state has now been removed, and some confusingly named types and variables have been normalized.
Most of the changes are `Battlesnake` -> `SnakeState` and removing references to a global `Battlesnakes` variable.