### PR TITLE
Add export to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 # General
 .DS_Store
+battlesnake-dev

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@
 
 # General
 .DS_Store
-battlesnake-dev
-test.jsonl
+
+# Build and Output 
+/battlesnake
+*.jsonl

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 # General
 .DS_Store
 battlesnake-dev
+test.jsonl

--- a/cli/commands/output.go
+++ b/cli/commands/output.go
@@ -79,9 +79,5 @@ func (ge *GameExporter) ConvertToJSON() ([]string, error) {
 }
 
 func (ge *GameExporter) AddSnakeRequest(snakeRequest client.SnakeRequest) {
-	if ge.snakeRequests == nil {
-		ge.snakeRequests = []client.SnakeRequest{snakeRequest}
-	} else {
-		ge.snakeRequests = append(ge.snakeRequests, snakeRequest)
-	}
+	ge.snakeRequests = append(ge.snakeRequests, snakeRequest)
 }

--- a/cli/commands/output.go
+++ b/cli/commands/output.go
@@ -1,0 +1,85 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/BattlesnakeOfficial/rules/client"
+)
+
+type GameExporter struct {
+	game          client.Game
+	snakeRequests []client.SnakeRequest
+	winner        SnakeState
+	isDraw        bool
+}
+
+type result struct {
+	winnerID   string `json:"winnerId"`
+	winnerName string `json:"winnerName"`
+	isDraw     bool   `json:"isDraw"`
+}
+
+func (ge *GameExporter) FlushToFile(filepath string, format string) error {
+	var formattedOutput []string
+	var formattingErr error
+
+	// TODO: Support more formats
+	if format == "JSONL" {
+		formattedOutput, formattingErr = ge.ConvertToJSON()
+	} else {
+		log.Fatalf("Invalid output format passed: %s", format)
+	}
+
+	if formattingErr != nil {
+		return formattingErr
+	}
+
+	f, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	for _, line := range formattedOutput {
+		f.WriteString(fmt.Sprintf("%s\n", line))
+	}
+
+	return nil
+}
+
+func (ge *GameExporter) ConvertToJSON() ([]string, error) {
+	output := make([]string, 0)
+	serialisedGame, err := json.Marshal(ge.game)
+	if err != nil {
+		return output, err
+	}
+	output = append(output, string(serialisedGame))
+	for _, board := range ge.snakeRequests {
+		serialisedBoard, err := json.Marshal(board)
+		if err != nil {
+			return output, err
+		}
+		output = append(output, string(serialisedBoard))
+	}
+	serialisedResult, err := json.Marshal(result{
+		winnerID:   ge.winner.ID,
+		winnerName: ge.winner.Name,
+		isDraw:     ge.isDraw,
+	})
+	if err != nil {
+		return output, err
+	}
+	output = append(output, string(serialisedResult))
+	return output, nil
+}
+
+func (ge *GameExporter) AddSnakeRequest(snakeRequest client.SnakeRequest) {
+	if ge.snakeRequests == nil {
+		ge.snakeRequests = []client.SnakeRequest{snakeRequest}
+	} else {
+		ge.snakeRequests = append(ge.snakeRequests, snakeRequest)
+	}
+}

--- a/cli/commands/output.go
+++ b/cli/commands/output.go
@@ -37,7 +37,7 @@ func (ge *GameExporter) FlushToFile(filepath string, format string) error {
 		return formattingErr
 	}
 
-	f, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+	f, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return err
 	}

--- a/cli/commands/output.go
+++ b/cli/commands/output.go
@@ -17,9 +17,9 @@ type GameExporter struct {
 }
 
 type result struct {
-	winnerID   string `json:"winnerId"`
-	winnerName string `json:"winnerName"`
-	isDraw     bool   `json:"isDraw"`
+	WinnerID   string `json:"winnerId"`
+	WinnerName string `json:"winnerName"`
+	IsDraw     bool   `json:"isDraw"`
 }
 
 func (ge *GameExporter) FlushToFile(filepath string, format string) error {
@@ -47,6 +47,8 @@ func (ge *GameExporter) FlushToFile(filepath string, format string) error {
 		f.WriteString(fmt.Sprintf("%s\n", line))
 	}
 
+	log.Printf("Written %d lines of output to file: %s\n", len(formattedOutput), filepath)
+
 	return nil
 }
 
@@ -65,9 +67,9 @@ func (ge *GameExporter) ConvertToJSON() ([]string, error) {
 		output = append(output, string(serialisedBoard))
 	}
 	serialisedResult, err := json.Marshal(result{
-		winnerID:   ge.winner.ID,
-		winnerName: ge.winner.Name,
-		isDraw:     ge.isDraw,
+		WinnerID:   ge.winner.ID,
+		WinnerName: ge.winner.Name,
+		IsDraw:     ge.isDraw,
 	})
 	if err != nil {
 		return output, err

--- a/cli/commands/output.go
+++ b/cli/commands/output.go
@@ -44,7 +44,10 @@ func (ge *GameExporter) FlushToFile(filepath string, format string) error {
 	defer f.Close()
 
 	for _, line := range formattedOutput {
-		f.WriteString(fmt.Sprintf("%s\n", line))
+		_, err := f.WriteString(fmt.Sprintf("%s\n", line))
+		if err != nil {
+			return err
+		}
 	}
 
 	log.Printf("Written %d lines of output to file: %s\n", len(formattedOutput), filepath)

--- a/cli/commands/play.go
+++ b/cli/commands/play.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"strconv"
 	"sync"
@@ -162,7 +163,11 @@ var run = func(cmd *cobra.Command, args []string) {
 	}
 
 	if exportGame {
-		gameExporter.FlushToFile(Output, "JSONL")
+		err := gameExporter.FlushToFile(Output, "JSONL")
+		if err != nil {
+			log.Printf("[WARN]: Unable to export game. Reason: %v\n", err.Error())
+			os.Exit(1)
+		}
 	}
 }
 

--- a/cli/commands/play.go
+++ b/cli/commands/play.go
@@ -126,10 +126,10 @@ var run = func(cmd *cobra.Command, args []string) {
 		if exportGame {
 			// The output file was designed in a way so that (nearly) every entry is equivalent to a valid API request.
 			// This is meant to help unlock further development of tools such as replaying a saved game by simply copying each line and sending it as a POST request.
-			// There was a design choice to be made here: the difference between SnakeResponse and BoardState is the `you` key.
-			// We could choose to either store the SnakeResponse of each snake OR to omit the `you` key OR fill the `you` key with one of the snakes
-			// In all cases the API request is technically non-compliant with how the actual API response should be.
-			// The third option (filling the `you` key with an arbitrary snake) is the closest to the actual API response that would need the least manipulation to
+			// There was a design choice to be made here: the difference between SnakeRequest and BoardState is the `you` key.
+			// We could choose to either store the SnakeRequest of each snake OR to omit the `you` key OR fill the `you` key with one of the snakes
+			// In all cases the API request is technically non-compliant with how the actual API request should be.
+			// The third option (filling the `you` key with an arbitrary snake) is the closest to the actual API request that would need the least manipulation to
 			// be adjusted to look like an API call for a specific snake in the game.
 			snakeState := snakeStates[state.Snakes[0].ID]
 			snakeRequest := getIndividualBoardStateForSnake(state, snakeState, snakeStates, ruleset)

--- a/cli/commands/play.go
+++ b/cli/commands/play.go
@@ -360,7 +360,7 @@ func getIndividualBoardStateForSnake(state *rules.BoardState, snakeState SnakeSt
 	request := client.SnakeRequest{
 		Game:  createClientGame(ruleset),
 		Turn:  Turn,
-		Board: convertStateToBoard(*state, snakeStates),
+		Board: convertStateToBoard(state, snakeStates),
 		You:   convertRulesSnake(youSnake, snakeStates[youSnake.ID]),
 	}
 	return request
@@ -425,7 +425,7 @@ func convertRulesSnakes(snakes []rules.Snake, snakeStates map[string]SnakeState)
 	return a
 }
 
-func convertStateToBoard(state rules.BoardState, snakeStates map[string]SnakeState) client.Board {
+func convertStateToBoard(state *rules.BoardState, snakeStates map[string]SnakeState) client.Board {
 	return client.Board{
 		Height:  state.Height,
 		Width:   state.Width,

--- a/cli/commands/play.go
+++ b/cli/commands/play.go
@@ -139,6 +139,7 @@ var run = func(cmd *cobra.Command, args []string) {
 	if GameType == "solo" {
 		log.Printf("[DONE]: Game completed after %v turns.", Turn)
 		if exportGame {
+			// These checks for exportGame are present to avoid vacuuming up RAM when an export is not requred.
 			gameExporter.winner = snakeStates[state.Snakes[0].ID]
 		}
 	} else {

--- a/cli/commands/play.go
+++ b/cli/commands/play.go
@@ -99,14 +99,11 @@ var run = func(cmd *cobra.Command, args []string) {
 	state := initializeBoardFromArgs(ruleset, snakeStates)
 	exportGame := Output != ""
 
-	var gameExporter GameExporter
-	if exportGame {
-		gameExporter = GameExporter{
-			game:          createClientGame(ruleset),
-			snakeRequests: make([]client.SnakeRequest, 0),
-			winner:        SnakeState{},
-			isDraw:        false,
-		}
+	gameExporter := GameExporter{
+		game:          createClientGame(ruleset),
+		snakeRequests: make([]client.SnakeRequest, 0),
+		winner:        SnakeState{},
+		isDraw:        false,
 	}
 
 	for v := false; !v; v, _ = ruleset.IsGameOver(state) {

--- a/cli/commands/play.go
+++ b/cli/commands/play.go
@@ -124,8 +124,13 @@ var run = func(cmd *cobra.Command, args []string) {
 		}
 
 		if exportGame {
-			// Pick first snake state
-			// TODO: Document this decision in both code and readme
+			// The output file was designed in a way so that (nearly) every entry is equivalent to a valid API request.
+			// This is meant to help unlock further development of tools such as replaying a saved game by simply copying each line and sending it as a POST request.
+			// There was a design choice to be made here: the difference between SnakeResponse and BoardState is the `you` key.
+			// We could choose to either store the SnakeResponse of each snake OR to omit the `you` key OR fill the `you` key with one of the snakes
+			// In all cases the API request is technically non-compliant with how the actual API response should be.
+			// The third option (filling the `you` key with an arbitrary snake) is the closest to the actual API response that would need the least manipulation to
+			// be adjusted to look like an API call for a specific snake in the game.
 			snakeState := snakeStates[state.Snakes[0].ID]
 			snakeRequest := getIndividualBoardStateForSnake(state, snakeState, snakeStates, ruleset)
 			gameExporter.AddSnakeRequest(snakeRequest)

--- a/cli/commands/play.go
+++ b/cli/commands/play.go
@@ -124,7 +124,6 @@ var run = func(cmd *cobra.Command, args []string) {
 		}
 
 		if exportGame {
-			log.Printf("Storing for export...\n")
 			// Pick first snake state
 			// TODO: Document this decision in both code and readme
 			snakeState := snakeStates[state.Snakes[0].ID]
@@ -142,11 +141,12 @@ var run = func(cmd *cobra.Command, args []string) {
 	} else {
 		var winner SnakeState
 		for _, snake := range state.Snakes {
+			snakeState := snakeStates[snake.ID]
 			if snake.EliminatedCause == rules.NotEliminated {
 				isDraw = false
-				winner = snakeStates[snake.ID]
+				winner = snakeState
 			}
-			sendEndRequest(ruleset, state, winner, snakeStates)
+			sendEndRequest(ruleset, state, snakeState, snakeStates)
 		}
 
 		if isDraw {

--- a/cli/commands/play_test.go
+++ b/cli/commands/play_test.go
@@ -35,7 +35,8 @@ func TestGetIndividualBoardStateForSnake(t *testing.T) {
 		s1State.ID: s1State,
 		s2State.ID: s2State,
 	}
-	requestBody := getIndividualBoardStateForSnake(state, s1State, snakeStates, &rules.StandardRuleset{})
+	snakeRequest := getIndividualBoardStateForSnake(state, s1State, snakeStates, &rules.StandardRuleset{})
+	requestBody := serialiseSnakeRequest(snakeRequest)
 
 	test.RequireJSONMatchesFixture(t, "testdata/snake_request_body.json", string(requestBody))
 }


### PR DESCRIPTION
This PR is the spiritual successor to the following now closed MR: #56.

Following the feedback from the community in the feedback repo [here](https://github.com/BattlesnakeOfficial/feedback/discussions/136) and some conversations on discord, here is a fresh MR which implements exporting of a BS game for further analysis.

The changes are:
* Every line except the last one match the payloads sent by the BS API. The only difference is that for POST /move, the `you` key is always filled with the first snake in the list. The reasoning behind this is documented in the relevant code block.
* The data is saved to memory at each iteration and flushed to file at the end of the game. This enables easier processing since a consumer can wait for the file to exist rather than have to tail the file and check for the final line.
* I did my best to cover the possibility of adding new formats / outputs (particularly stdout) without having to refactor everything from scratch

In my initial testing, a 4 snake 150 turn game produces a file of around 400KB, which then gzips down to 11KB.

I'm happy to receive feedback on my approach :ear: 