### PR TITLE
Add hazard sides

### DIFF
--- a/board.go
+++ b/board.go
@@ -2,13 +2,21 @@ package rules
 
 import "math/rand"
 
+type HazardSides struct {
+	MinX int32
+	MaxX int32
+	MinY int32
+	MaxY int32
+}
+
 type BoardState struct {
-	Turn    int32
-	Height  int32
-	Width   int32
-	Food    []Point
-	Snakes  []Snake
-	Hazards []Point
+	Turn        int32
+	Height      int32
+	Width       int32
+	Food        []Point
+	Snakes      []Snake
+	Hazards     []Point
+	HazardSides *HazardSides
 }
 
 // NewBoardState returns an empty but fully initialized BoardState

--- a/cli/commands/play.go
+++ b/cli/commands/play.go
@@ -431,12 +431,24 @@ func convertRulesSnakes(snakes []rules.Snake, snakeStates map[string]SnakeState)
 }
 
 func convertStateToBoard(state *rules.BoardState, snakeStates map[string]SnakeState) client.Board {
+	var clSides *client.HazardSides
+	fmt.Println(state.HazardSides)
+	if state.HazardSides != nil {
+		clSides = &client.HazardSides{
+			MinX: state.HazardSides.MinX,
+			MaxX: state.HazardSides.MaxX,
+			MinY: state.HazardSides.MinY,
+			MaxY: state.HazardSides.MaxY,
+		}
+	}
+	fmt.Println(clSides)
 	return client.Board{
-		Height:  state.Height,
-		Width:   state.Width,
-		Food:    client.CoordFromPointArray(state.Food),
-		Hazards: client.CoordFromPointArray(state.Hazards),
-		Snakes:  convertRulesSnakes(state.Snakes, snakeStates),
+		Height:      state.Height,
+		Width:       state.Width,
+		Food:        client.CoordFromPointArray(state.Food),
+		Hazards:     client.CoordFromPointArray(state.Hazards),
+		HazardSides: clSides,
+		Snakes:      convertRulesSnakes(state.Snakes, snakeStates),
 	}
 }
 

--- a/cli/commands/play_test.go
+++ b/cli/commands/play_test.go
@@ -40,3 +40,43 @@ func TestGetIndividualBoardStateForSnake(t *testing.T) {
 
 	test.RequireJSONMatchesFixture(t, "testdata/snake_request_body.json", string(requestBody))
 }
+
+func TestGetIndividualBoardStateForSnakeHazardSides(t *testing.T) {
+	s1 := rules.Snake{ID: "one", Body: []rules.Point{{X: 3, Y: 3}}}
+	s2 := rules.Snake{ID: "two", Body: []rules.Point{{X: 4, Y: 3}}}
+	state := &rules.BoardState{
+		Height: 11,
+		Width:  11,
+		Snakes: []rules.Snake{s1, s2},
+		HazardSides: &rules.HazardSides{
+			MinX: 3,
+			MaxX: 5,
+			MinY: 7,
+			MaxY: 9,
+		},
+	}
+	s1State := SnakeState{
+		ID:    "one",
+		Name:  "ONE",
+		URL:   "http://example1.com",
+		Head:  "safe",
+		Tail:  "curled",
+		Color: "#123456",
+	}
+	s2State := SnakeState{
+		ID:    "two",
+		Name:  "TWO",
+		URL:   "http://example2.com",
+		Head:  "silly",
+		Tail:  "bolt",
+		Color: "#654321",
+	}
+	snakeStates := map[string]SnakeState{
+		s1State.ID: s1State,
+		s2State.ID: s2State,
+	}
+	snakeRequest := getIndividualBoardStateForSnake(state, s1State, snakeStates, &rules.StandardRuleset{})
+	requestBody := serialiseSnakeRequest(snakeRequest)
+
+	test.RequireJSONMatchesFixture(t, "testdata/snake_request_body_hazard_sides.json", string(requestBody))
+}

--- a/cli/commands/testdata/snake_request_body_hazard_sides.json
+++ b/cli/commands/testdata/snake_request_body_hazard_sides.json
@@ -1,0 +1,112 @@
+{
+  "game": {
+    "id": "",
+    "ruleset": {
+      "name": "standard",
+      "version": "cli",
+      "settings": {
+        "foodSpawnChance": 15,
+        "minimumFood": 1,
+        "hazardDamagePerTurn": 14,
+        "royale": {
+          "shrinkEveryNTurns": 25
+        },
+        "squad": {
+          "allowBodyCollisions": true,
+          "sharedElimination": true,
+          "sharedHealth": true,
+          "sharedLength": true
+        }
+      }
+    },
+    "timeout": 500,
+    "source": ""
+  },
+  "turn": 0,
+  "board": {
+    "height": 11,
+    "width": 11,
+    "hazardSides": {
+        "minX": 3,
+        "maxX": 5,
+        "minY": 7,
+        "maxY": 9
+    },
+    "snakes": [
+      {
+        "id": "one",
+        "name": "ONE",
+        "latency": "0",
+        "health": 0,
+        "body": [
+          {
+            "x": 3,
+            "y": 3
+          }
+        ],
+        "head": {
+          "x": 3,
+          "y": 3
+        },
+        "length": 1,
+        "shout": "",
+        "squad": "",
+        "customizations": {
+          "color": "#123456",
+          "head": "safe",
+          "tail": "curled"
+        }
+      },
+      {
+        "id": "two",
+        "name": "TWO",
+        "latency": "0",
+        "health": 0,
+        "body": [
+          {
+            "x": 4,
+            "y": 3
+          }
+        ],
+        "head": {
+          "x": 4,
+          "y": 3
+        },
+        "length": 1,
+        "shout": "",
+        "squad": "",
+        "customizations": {
+          "color": "#654321",
+          "head": "silly",
+          "tail": "bolt"
+        }
+      }
+    ],
+    "food": [],
+    "hazards": []
+  },
+  "you": {
+    "id": "one",
+    "name": "ONE",
+    "latency": "0",
+    "health": 0,
+    "body": [
+      {
+        "x": 3,
+        "y": 3
+      }
+    ],
+    "head": {
+      "x": 3,
+      "y": 3
+    },
+    "length": 1,
+    "shout": "",
+    "squad": "",
+    "customizations": {
+      "color": "#123456",
+      "head": "safe",
+      "tail": "curled"
+    }
+  }
+}

--- a/client/models.go
+++ b/client/models.go
@@ -20,11 +20,20 @@ type Game struct {
 
 // Board provides information about the game board
 type Board struct {
-	Height  int32   `json:"height"`
-	Width   int32   `json:"width"`
-	Snakes  []Snake `json:"snakes"`
-	Food    []Coord `json:"food"`
-	Hazards []Coord `json:"hazards"`
+	Height      int32        `json:"height"`
+	Width       int32        `json:"width"`
+	Snakes      []Snake      `json:"snakes"`
+	Food        []Coord      `json:"food"`
+	Hazards     []Coord      `json:"hazards"`
+	HazardSides *HazardSides `json:"hazardSides,omitempty"`
+}
+
+// What sides the hazards have spawned in from
+type HazardSides struct {
+	MinX int32 `json:"minX"`
+	MaxX int32 `json:"maxX"`
+	MinY int32 `json:"minY"`
+	MaxY int32 `json:"maxY"`
 }
 
 // Snake represents information about a snake in the game

--- a/royale.go
+++ b/royale.go
@@ -71,5 +71,12 @@ func (r *RoyaleRuleset) populateHazards(b *BoardState, turn int32) error {
 		}
 	}
 
+	b.HazardSides = &HazardSides{
+		MinX: minX,
+		MaxX: maxX,
+		MinY: minY,
+		MaxY: maxY,
+	}
+
 	return nil
 }


### PR DESCRIPTION
this patch implements my feedback of sending the hazard sides along with the request payload. I used a pointer and `omitempty` to ensure it only gets set when the data is actually there. I added a test