### PR TITLE
added TurnDuration option to cli

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -33,6 +33,7 @@ Usage:
 
 Flags:
   -d, --delay int32         Turn Delay in Milliseconds (default 0)
+  -D, --duration int32      Minimum Turn Duration in Milliseconds (default 0)
   -g, --gametype string     Type of Game Rules (default "standard")
   -H, --height int32        Height of Board (default 11)
   -h, --help                help for play

--- a/cli/commands/play.go
+++ b/cli/commands/play.go
@@ -43,6 +43,7 @@ var Names []string
 var URLs []string
 var Squads []string
 var Timeout int32
+var TurnDuration int32
 var Sequential bool
 var GameType string
 var ViewMap bool
@@ -79,6 +80,7 @@ func init() {
 	playCmd.Flags().BoolVarP(&UseColor, "color", "c", false, "Use color to draw the map")
 	playCmd.Flags().Int64VarP(&Seed, "seed", "r", time.Now().UTC().UnixNano(), "Random Seed")
 	playCmd.Flags().Int32VarP(&TurnDelay, "delay", "d", 0, "Turn Delay in Milliseconds")
+	playCmd.Flags().Int32VarP(&TurnDuration, "duration", "D", 0, "Minimum Turn Duration in Milliseconds")
 	playCmd.Flags().BoolVar(&DebugRequests, "debug-requests", false, "Log body of all requests sent")
 	playCmd.Flags().StringVarP(&Output, "output", "o", "", "File path to output game state to. Existing files will be overwritten")
 
@@ -96,6 +98,7 @@ var run = func(cmd *cobra.Command, args []string) {
 	GameId = uuid.New().String()
 	Turn = 0
 
+	var endTime time.Time
 	snakeStates := buildSnakesFromOptions()
 
 	ruleset := getRuleset(Seed, snakeStates)
@@ -110,6 +113,10 @@ var run = func(cmd *cobra.Command, args []string) {
 	}
 
 	for v := false; !v; v, _ = ruleset.IsGameOver(state) {
+		if TurnDuration > 0 {
+			endTime = time.Now().Add(time.Duration(TurnDuration) * time.Millisecond)
+		}
+
 		Turn++
 		state = createNextBoardState(ruleset, state, snakeStates, Turn)
 
@@ -121,6 +128,10 @@ var run = func(cmd *cobra.Command, args []string) {
 
 		if TurnDelay > 0 {
 			time.Sleep(time.Duration(TurnDelay) * time.Millisecond)
+		}
+
+		if TurnDuration > 0 {
+			time.Sleep(time.Until(endTime))
 		}
 
 		if exportGame {


### PR DESCRIPTION
Add turn duration cli option, which specifies minimum turn duration in milliseconds. This enables the user to set a consistent turn step time regardless of the latency of snakes. 

Feature requested by discord user BoldBigflank:
> I would like to delay the game from moving on to the next turn to 500ms every turn, no matter the latency of the snakes
> Because I'm setting up a LED display to show snake games, I want it to be at a set pace