### PR TITLE
Add hazardMap and hazardMapAuthor to RulesetSettings

### DIFF
--- a/cli/commands/testdata/snake_request_body.json
+++ b/cli/commands/testdata/snake_request_body.json
@@ -8,6 +8,8 @@
         "foodSpawnChance": 15,
         "minimumFood": 1,
         "hazardDamagePerTurn": 14,
+        "hazardMap": "",
+        "hazardMapAuthor": "",
         "royale": {
           "shrinkEveryNTurns": 25
         },

--- a/client/fixtures_test.go
+++ b/client/fixtures_test.go
@@ -76,6 +76,8 @@ var exampleRulesetSettings = RulesetSettings{
 	FoodSpawnChance:     10,
 	MinimumFood:         20,
 	HazardDamagePerTurn: 30,
+	HazardMap:           "hz_spiral",
+	HazardMapAuthor:     "altersaddle",
 
 	RoyaleSettings: RoyaleSettings{
 		ShrinkEveryNTurns: 40,

--- a/client/models.go
+++ b/client/models.go
@@ -57,6 +57,8 @@ type RulesetSettings struct {
 	FoodSpawnChance     int32          `json:"foodSpawnChance"`
 	MinimumFood         int32          `json:"minimumFood"`
 	HazardDamagePerTurn int32          `json:"hazardDamagePerTurn"`
+	HazardMap           string         `json:"hazardMap"`
+	HazardMapAuthor     string         `json:"hazardMapAuthor"`
 	RoyaleSettings      RoyaleSettings `json:"royale"`
 	SquadSettings       SquadSettings  `json:"squad"`
 }

--- a/client/testdata/snake_request.json
+++ b/client/testdata/snake_request.json
@@ -8,8 +8,8 @@
         "foodSpawnChance": 10,
         "minimumFood": 20,
         "hazardDamagePerTurn": 30,
-        "hazardMap": "",
-        "hazardMapAuthor": "",
+        "hazardMap": "hz_spiral",
+        "hazardMapAuthor": "altersaddle",
         "royale": {
           "shrinkEveryNTurns": 40
         },

--- a/client/testdata/snake_request.json
+++ b/client/testdata/snake_request.json
@@ -8,6 +8,8 @@
         "foodSpawnChance": 10,
         "minimumFood": 20,
         "hazardDamagePerTurn": 30,
+        "hazardMap": "",
+        "hazardMapAuthor": "",
         "royale": {
           "shrinkEveryNTurns": 40
         },

--- a/client/testdata/snake_request_empty_ruleset_settings.json
+++ b/client/testdata/snake_request_empty_ruleset_settings.json
@@ -8,6 +8,8 @@
         "foodSpawnChance": 0,
         "minimumFood": 0,
         "hazardDamagePerTurn": 0,
+        "hazardMap": "",
+        "hazardMapAuthor": "",
         "royale": {
           "shrinkEveryNTurns": 0
         },


### PR DESCRIPTION
Once this update has been pulled into the engine, these new properties will be sent along to all Battlesnakes in the ruleset settings object:
- `hazardMap`
- `hazardMapAuthor`