### PR TITLE
Fix invalid request to /end when game ended in a draw

### DIFF
--- a/cli/commands/play.go
+++ b/cli/commands/play.go
@@ -392,7 +392,7 @@ func convertRulesSnake(snake rules.Snake, snakeState SnakeState) client.Snake {
 }
 
 func convertRulesSnakes(snakes []rules.Snake, snakeStates map[string]SnakeState) []client.Snake {
-	var a []client.Snake
+	a := make([]client.Snake, 0)
 	for _, snake := range snakes {
 		if snake.EliminatedCause == rules.NotEliminated {
 			a = append(a, convertRulesSnake(snake, snakeStates[snake.ID]))


### PR DESCRIPTION
If game ends in a draw, all snakes are eliminated. In that scenario after marshalling to json, the value of `board.snakes` field would be set to `null` instead of `[]`. The bug was introduced in  https://github.com/BattlesnakeOfficial/rules/commit/dabbe7dfb5bd110983569b1ceb0a8098f1bc33b3 .
