### PR TITLE
DEV-1096 - add a new "pipeline" concept

### DIFF
--- a/board.go
+++ b/board.go
@@ -5,6 +5,9 @@ import (
 )
 
 type BoardState struct {
+	// Turn is the current turn.
+	// Turn 0 is a special case that is used for initialisation.
+	// Turn 1+ is a regular turn where snakes move etc...
 	Turn    int32
 	Height  int32
 	Width   int32

--- a/board.go
+++ b/board.go
@@ -5,9 +5,6 @@ import (
 )
 
 type BoardState struct {
-	// Turn is the current turn.
-	// Turn 0 is a special case that is used for initialisation.
-	// Turn 1+ is a regular turn where snakes move etc...
 	Turn    int32
 	Height  int32
 	Width   int32

--- a/board.go
+++ b/board.go
@@ -25,7 +25,7 @@ func NewBoardState(width, height int32) *BoardState {
 	}
 }
 
-// Clone returns a deep copy of prevState that can be safely modified inside Ruleset.CreateNextBoardState
+// Clone returns a deep copy of prevState that can be safely modified without affecting the original
 func (prevState *BoardState) Clone() *BoardState {
 	nextState := &BoardState{
 		Turn:    prevState.Turn,

--- a/cases_test.go
+++ b/cases_test.go
@@ -26,7 +26,9 @@ func (gc *gameTestCase) clone() *gameTestCase {
 
 // requireValidNextState requires that the ruleset produces a valid next state
 func (gc *gameTestCase) requireValidNextState(t *testing.T, r Ruleset) {
+	t.Helper()
 	t.Run(gc.name, func(t *testing.T) {
+		t.Helper()
 		prev := gc.prevState.Clone() // clone to protect against mutation (so we can ru-use test cases)
 		nextState, err := r.CreateNextBoardState(prev, gc.moves)
 		require.Equal(t, gc.expectedError, err)

--- a/cases_test.go
+++ b/cases_test.go
@@ -39,3 +39,9 @@ func (gc *gameTestCase) requireValidNextState(t *testing.T, r Ruleset) {
 		}
 	})
 }
+
+func mockSnakeMoves() []SnakeMove {
+	return []SnakeMove{
+		{ID: "test-mock-move", Move: "mocked"},
+	}
+}

--- a/constrictor.go
+++ b/constrictor.go
@@ -37,13 +37,11 @@ func (r *ConstrictorRuleset) ModifyInitialBoardState(initialBoardState *BoardSta
 }
 
 func (r *ConstrictorRuleset) CreateNextBoardState(prevState *BoardState, moves []SnakeMove) (*BoardState, error) {
-	nextState := prevState.Clone()
-
 	p, err := r.Pipeline()
 	if err != nil {
 		return nil, err
 	}
-	_, err = p.Execute(nextState, r.Settings(), moves)
+	_, nextState, err := p.Execute(prevState, r.Settings(), moves)
 
 	return nextState, err
 }

--- a/constrictor.go
+++ b/constrictor.go
@@ -21,19 +21,13 @@ func (r ConstrictorRuleset) Pipeline() (*Pipeline, error) {
 }
 
 func (r *ConstrictorRuleset) ModifyInitialBoardState(initialBoardState *BoardState) (*BoardState, error) {
-	initialBoardState, err := r.StandardRuleset.ModifyInitialBoardState(initialBoardState)
+	p, err := r.Pipeline()
 	if err != nil {
 		return nil, err
 	}
 
-	r.removeFood(initialBoardState)
-
-	err = r.applyConstrictorRules(initialBoardState)
-	if err != nil {
-		return nil, err
-	}
-
-	return initialBoardState, nil
+	_, nextState, err := p.Execute(initialBoardState, r.Settings(), nil)
+	return nextState, err
 }
 
 func (r *ConstrictorRuleset) CreateNextBoardState(prevState *BoardState, moves []SnakeMove) (*BoardState, error) {
@@ -46,20 +40,11 @@ func (r *ConstrictorRuleset) CreateNextBoardState(prevState *BoardState, moves [
 	return nextState, err
 }
 
-func (r *ConstrictorRuleset) removeFood(b *BoardState) {
-	_, _ = r.callStageFunc(RemoveFoodConstrictor, b, []SnakeMove{})
-}
-
 func RemoveFoodConstrictor(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
 	// Remove all food from the board
 	b.Food = []Point{}
 
 	return false, nil
-}
-
-func (r *ConstrictorRuleset) applyConstrictorRules(b *BoardState) error {
-	_, err := r.callStageFunc(GrowSnakesConstrictor, b, []SnakeMove{})
-	return err
 }
 
 func GrowSnakesConstrictor(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {

--- a/constrictor.go
+++ b/constrictor.go
@@ -5,7 +5,6 @@ var constrictorRulesetStages = []string{
 	StageStarvationStandard,
 	StageHazardDamageStandard,
 	StageFeedSnakesStandard,
-	StageSpawnFoodStandard,
 	StageEliminationStandard,
 	StageSpawnFoodNoFood,
 	StageModifySnakesAlwaysGrow,

--- a/constrictor.go
+++ b/constrictor.go
@@ -1,15 +1,15 @@
 package rules
 
 var constrictorRulesetStages = []string{
-	"snake.movement.standard",
-	"health.reduce.standard",
-	"hazard.damage.standard",
-	"snake.eatfood.standard",
-	"food.spawn.standard",
-	"snake.eliminate.standard",
-	"food.remove.constrictor",
-	"snake.grow.constrictor",
-	"gameover.standard",
+	StageMovementStandard,
+	StageStarvationStandard,
+	StageHazardDamageStandard,
+	StageFeedSnakesStandard,
+	StageSpawnFoodStandard,
+	StageEliminationStandard,
+	StageSpawnFoodNoFood,
+	StageModifySnakesAlwaysGrow,
+	StageGameOverStandard,
 }
 
 type ConstrictorRuleset struct {

--- a/constrictor.go
+++ b/constrictor.go
@@ -7,20 +7,17 @@ type ConstrictorRuleset struct {
 func (r *ConstrictorRuleset) Name() string { return GameTypeConstrictor }
 
 func (r ConstrictorRuleset) Pipeline() (*Pipeline, error) {
-	// The constrictor pipeline extends the standard pipeline
-	standard, err := r.StandardRuleset.Pipeline()
-	if err != nil {
-		return nil, err
-	}
-
-	constrictor, err := NewPipeline(
+	return NewPipeline(
+		"movement.standard",
+		"reducehealth.standard",
+		"hazarddamage.standard",
+		"eatfood.standard",
+		"placefood.standard",
+		"eliminatesnake.standard",
 		"removefood.constrictor",
 		"growsnake.constrictor",
+		"gameover.standard",
 	)
-	if err != nil {
-		return nil, err
-	}
-	return standard.Append(constrictor), nil
 }
 
 func (r *ConstrictorRuleset) ModifyInitialBoardState(initialBoardState *BoardState) (*BoardState, error) {

--- a/constrictor.go
+++ b/constrictor.go
@@ -8,14 +8,14 @@ func (r *ConstrictorRuleset) Name() string { return GameTypeConstrictor }
 
 func (r ConstrictorRuleset) Pipeline() (*Pipeline, error) {
 	return NewPipeline(
-		"movement.standard",
-		"reducehealth.standard",
-		"hazarddamage.standard",
-		"eatfood.standard",
-		"placefood.standard",
-		"eliminatesnake.standard",
-		"removefood.constrictor",
-		"growsnake.constrictor",
+		"snake.movement.standard",
+		"health.reduce.standard",
+		"hazard.damage.standard",
+		"snake.eatfood.standard",
+		"food.spawn.standard",
+		"snake.eliminate.standard",
+		"food.remove.constrictor",
+		"snake.grow.constrictor",
 		"gameover.standard",
 	)
 }

--- a/constrictor.go
+++ b/constrictor.go
@@ -32,6 +32,11 @@ func (r *ConstrictorRuleset) CreateNextBoardState(prevState *BoardState, moves [
 	return nextState, err
 }
 
+func (r *ConstrictorRuleset) IsGameOver(b *BoardState) (bool, error) {
+	gameover, _, err := r.Execute(b, r.Settings(), nil)
+	return gameover, err
+}
+
 func RemoveFoodConstrictor(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
 	// Remove all food from the board
 	b.Food = []Point{}

--- a/constrictor.go
+++ b/constrictor.go
@@ -1,41 +1,34 @@
 package rules
 
+var constrictorRulesetStages = []string{
+	"snake.movement.standard",
+	"health.reduce.standard",
+	"hazard.damage.standard",
+	"snake.eatfood.standard",
+	"food.spawn.standard",
+	"snake.eliminate.standard",
+	"food.remove.constrictor",
+	"snake.grow.constrictor",
+	"gameover.standard",
+}
+
 type ConstrictorRuleset struct {
 	StandardRuleset
 }
 
 func (r *ConstrictorRuleset) Name() string { return GameTypeConstrictor }
 
-func (r ConstrictorRuleset) Pipeline() (*Pipeline, error) {
-	return NewPipeline(
-		"snake.movement.standard",
-		"health.reduce.standard",
-		"hazard.damage.standard",
-		"snake.eatfood.standard",
-		"food.spawn.standard",
-		"snake.eliminate.standard",
-		"food.remove.constrictor",
-		"snake.grow.constrictor",
-		"gameover.standard",
-	)
+func (r ConstrictorRuleset) Execute(bs *BoardState, s Settings, sm []SnakeMove) (bool, *BoardState, error) {
+	return NewPipeline(constrictorRulesetStages...).Execute(bs, s, sm)
 }
 
 func (r *ConstrictorRuleset) ModifyInitialBoardState(initialBoardState *BoardState) (*BoardState, error) {
-	p, err := r.Pipeline()
-	if err != nil {
-		return nil, err
-	}
-
-	_, nextState, err := p.Execute(initialBoardState, r.Settings(), nil)
+	_, nextState, err := r.Execute(initialBoardState, r.Settings(), nil)
 	return nextState, err
 }
 
 func (r *ConstrictorRuleset) CreateNextBoardState(prevState *BoardState, moves []SnakeMove) (*BoardState, error) {
-	p, err := r.Pipeline()
-	if err != nil {
-		return nil, err
-	}
-	_, nextState, err := p.Execute(prevState, r.Settings(), moves)
+	_, nextState, err := r.Execute(prevState, r.Settings(), moves)
 
 	return nextState, err
 }

--- a/constrictor.go
+++ b/constrictor.go
@@ -33,8 +33,7 @@ func (r *ConstrictorRuleset) CreateNextBoardState(prevState *BoardState, moves [
 }
 
 func (r *ConstrictorRuleset) IsGameOver(b *BoardState) (bool, error) {
-	gameover, _, err := r.Execute(b, r.Settings(), nil)
-	return gameover, err
+	return GameOverStandard(b, r.Settings(), nil)
 }
 
 func RemoveFoodConstrictor(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {

--- a/constrictor.go
+++ b/constrictor.go
@@ -7,7 +7,7 @@ type ConstrictorRuleset struct {
 func (r *ConstrictorRuleset) Name() string { return GameTypeConstrictor }
 
 func (r ConstrictorRuleset) Pipeline() (*Pipeline, error) {
-	// The squad pipeline extends the standard pipeline
+	// The constrictor pipeline extends the standard pipeline
 	standard, err := r.StandardRuleset.Pipeline()
 	if err != nil {
 		return nil, err

--- a/constrictor.go
+++ b/constrictor.go
@@ -47,6 +47,9 @@ func RemoveFoodConstrictor(b *BoardState, settings Settings, moves []SnakeMove) 
 func GrowSnakesConstrictor(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
 	// Set all snakes to max health and ensure they grow next turn
 	for i := 0; i < len(b.Snakes); i++ {
+		if len(b.Snakes[i].Body) <= 0 {
+			return false, ErrorZeroLengthSnake
+		}
 		b.Snakes[i].Health = SnakeMaxHealth
 
 		tail := b.Snakes[i].Body[len(b.Snakes[i].Body)-1]

--- a/constrictor_test.go
+++ b/constrictor_test.go
@@ -103,8 +103,15 @@ func TestConstrictorCreateNextBoardState(t *testing.T) {
 		standardCaseErrZeroLengthSnake,
 		constrictorMoveAndCollideMAD,
 	}
+	rb := NewRulesetBuilder().WithParams(map[string]string{
+		ParamGameType: GameTypeConstrictor,
+	})
 	r := ConstrictorRuleset{}
 	for _, gc := range cases {
 		gc.requireValidNextState(t, &r)
+		// also test a RulesBuilder constructed instance
+		gc.requireValidNextState(t, rb.Ruleset())
+		// also test a pipeline with the same settings
+		gc.requireValidNextState(t, rb.PipelineRuleset(GameTypeConstrictor, NewPipeline(constrictorRulesetStages...)))
 	}
 }

--- a/constrictor_test.go
+++ b/constrictor_test.go
@@ -10,50 +10,26 @@ func TestConstrictorRulesetInterface(t *testing.T) {
 	var _ Ruleset = (*ConstrictorRuleset)(nil)
 }
 
-var initialBoarStateTests = []struct {
-	Height int32
-	Width  int32
-	IDs    []string
-}{
-	{1, 1, []string{}},
-	{1, 1, []string{"one"}},
-	{2, 2, []string{"one"}},
-	{2, 2, []string{"one", "two"}},
-	{11, 1, []string{"one", "two"}},
-	{11, 11, []string{}},
-	{11, 11, []string{"one", "two", "three", "four", "five"}},
-}
-
 func TestConstrictorModifyInitialBoardState(t *testing.T) {
+	tests := []struct {
+		Height int32
+		Width  int32
+		IDs    []string
+	}{
+		{1, 1, []string{}},
+		{1, 1, []string{"one"}},
+		{2, 2, []string{"one"}},
+		{2, 2, []string{"one", "two"}},
+		{11, 1, []string{"one", "two"}},
+		{11, 11, []string{}},
+		{11, 11, []string{"one", "two", "three", "four", "five"}},
+	}
 	r := ConstrictorRuleset{}
-	for testNum, test := range initialBoarStateTests {
+	for testNum, test := range tests {
 		state, err := CreateDefaultBoardState(test.Width, test.Height, test.IDs)
 		require.NoError(t, err)
 		require.NotNil(t, state)
 		state, err = r.ModifyInitialBoardState(state)
-		require.NoError(t, err)
-		require.NotNil(t, state)
-		require.Equal(t, test.Width, state.Width)
-		require.Equal(t, test.Height, state.Height)
-		require.Len(t, state.Food, 0, testNum)
-		// Verify snakes
-		require.Equal(t, len(test.IDs), len(state.Snakes))
-		for i, id := range test.IDs {
-			require.Equal(t, id, state.Snakes[i].ID)
-			require.Equal(t, state.Snakes[i].Body[2], state.Snakes[i].Body[1])
-		}
-	}
-}
-
-func TestConstrictorPipelineInitialBoardState(t *testing.T) {
-	r := ConstrictorRuleset{}
-	for testNum, test := range initialBoarStateTests {
-		state, err := CreateDefaultBoardState(test.Width, test.Height, test.IDs)
-		require.NoError(t, err)
-		require.NotNil(t, state)
-		p, err := r.Pipeline()
-		require.NoError(t, err)
-		_, state, err = p.Execute(state, r.Settings(), nil)
 		require.NoError(t, err)
 		require.NotNil(t, state)
 		require.Equal(t, test.Width, state.Width)

--- a/constrictor_test.go
+++ b/constrictor_test.go
@@ -10,27 +10,50 @@ func TestConstrictorRulesetInterface(t *testing.T) {
 	var _ Ruleset = (*ConstrictorRuleset)(nil)
 }
 
-func TestConstrictorModifyInitialBoardState(t *testing.T) {
-	tests := []struct {
-		Height int32
-		Width  int32
-		IDs    []string
-	}{
-		{1, 1, []string{}},
-		{1, 1, []string{"one"}},
-		{2, 2, []string{"one"}},
-		{2, 2, []string{"one", "two"}},
-		{11, 1, []string{"one", "two"}},
-		{11, 11, []string{}},
-		{11, 11, []string{"one", "two", "three", "four", "five"}},
-	}
+var initialBoarStateTests = []struct {
+	Height int32
+	Width  int32
+	IDs    []string
+}{
+	{1, 1, []string{}},
+	{1, 1, []string{"one"}},
+	{2, 2, []string{"one"}},
+	{2, 2, []string{"one", "two"}},
+	{11, 1, []string{"one", "two"}},
+	{11, 11, []string{}},
+	{11, 11, []string{"one", "two", "three", "four", "five"}},
+}
 
+func TestConstrictorModifyInitialBoardState(t *testing.T) {
 	r := ConstrictorRuleset{}
-	for testNum, test := range tests {
+	for testNum, test := range initialBoarStateTests {
 		state, err := CreateDefaultBoardState(test.Width, test.Height, test.IDs)
 		require.NoError(t, err)
 		require.NotNil(t, state)
 		state, err = r.ModifyInitialBoardState(state)
+		require.NoError(t, err)
+		require.NotNil(t, state)
+		require.Equal(t, test.Width, state.Width)
+		require.Equal(t, test.Height, state.Height)
+		require.Len(t, state.Food, 0, testNum)
+		// Verify snakes
+		require.Equal(t, len(test.IDs), len(state.Snakes))
+		for i, id := range test.IDs {
+			require.Equal(t, id, state.Snakes[i].ID)
+			require.Equal(t, state.Snakes[i].Body[2], state.Snakes[i].Body[1])
+		}
+	}
+}
+
+func TestConstrictorPipelineInitialBoardState(t *testing.T) {
+	r := ConstrictorRuleset{}
+	for testNum, test := range initialBoarStateTests {
+		state, err := CreateDefaultBoardState(test.Width, test.Height, test.IDs)
+		require.NoError(t, err)
+		require.NotNil(t, state)
+		p, err := r.Pipeline()
+		require.NoError(t, err)
+		_, state, err = p.Execute(state, r.Settings(), nil)
 		require.NoError(t, err)
 		require.NotNil(t, state)
 		require.Equal(t, test.Width, state.Width)

--- a/pipeline.go
+++ b/pipeline.go
@@ -117,23 +117,28 @@ func (p *Pipeline) Append(p2 *Pipeline) *Pipeline {
 	}
 }
 
-// Execute runs all of the pipeline stages and produces a next game state.
+// Execute runs all of the pipeline stages and produces a next game state
+// by cloning the original state and applying stages to modify the cloned, next state.
+//
 // If any stage produces an error or an ended game state, the pipeline
 // immediately stops at that stage.
+//
 // The result is always the result of the last stage that was executed.
-func (p *Pipeline) Execute(state *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
+//
+func (p *Pipeline) Execute(state *BoardState, settings Settings, moves []SnakeMove) (bool, *BoardState, error) {
 	var ended bool
 	var err error
+	state = state.Clone()
 	for _, fn := range p.stages {
 		// execute current stage
 		ended, err = fn(state, settings, moves)
 
 		// stop if we hit any errors or if the game is ended
 		if err != nil || ended {
-			return ended, err
+			return ended, state, err
 		}
 	}
 
 	// return the result of the last stage as the final pipeline result
-	return ended, err
+	return ended, state, err
 }

--- a/pipeline.go
+++ b/pipeline.go
@@ -13,20 +13,20 @@ type StageRegistry map[string]StageFunc
 // to add additional stages.
 var globalRegistry = StageRegistry{
 	"food.remove.constrictor":  RemoveFoodConstrictor,
-	"food.spawn.standard":      WithNoOpOnInit(SpawnFoodStandard),
-	"gameover.solo":            WithNoOpOnInit(GameOverSolo),
-	"gameover.squad":           WithNoOpOnInit(GameOverSquad),
-	"gameover.standard":        WithNoOpOnInit(GameOverStandard),
-	"hazard.damage.standard":   WithNoOpOnInit(DamageHazardsStandard),
-	"hazard.spawn.royale":      WithNoOpOnInit(PopulateHazardsRoyale),
-	"health.reduce.standard":   WithNoOpOnInit(ReduceSnakeHealthStandard),
-	"snake.collision.squad":    WithNoOpOnInit(ResurrectSnakesSquad),
-	"snake.eatfood.standard":   WithNoOpOnInit(FeedSnakesStandard),
-	"snake.eliminate.standard": WithNoOpOnInit(EliminateSnakesStandard),
+	"food.spawn.standard":      SpawnFoodStandard,
+	"gameover.solo":            GameOverSolo,
+	"gameover.squad":           GameOverSquad,
+	"gameover.standard":        GameOverStandard,
+	"hazard.damage.standard":   DamageHazardsStandard,
+	"hazard.spawn.royale":      PopulateHazardsRoyale,
+	"health.reduce.standard":   ReduceSnakeHealthStandard,
+	"snake.collision.squad":    ResurrectSnakesSquad,
+	"snake.eatfood.standard":   FeedSnakesStandard,
+	"snake.eliminate.standard": EliminateSnakesStandard,
 	"snake.grow.constrictor":   GrowSnakesConstrictor,
-	"snake.movement.standard":  WithNoOpOnInit(MoveSnakesStandard),
-	"snake.movement.wrapped":   WithNoOpOnInit(MoveSnakesWrapped),
-	"snake.share.squad":        WithNoOpOnInit(ShareAttributesSquad),
+	"snake.movement.standard":  MoveSnakesStandard,
+	"snake.movement.wrapped":   MoveSnakesWrapped,
+	"snake.share.squad":        ShareAttributesSquad,
 }
 
 // RegisterPipelineStage adds a stage to the registry.

--- a/pipeline.go
+++ b/pipeline.go
@@ -7,23 +7,23 @@ import (
 // StageRegistry is a mapping of stage names to stage functions
 type StageRegistry map[string]StageFunc
 
-// globalRegistry is a global mapping of stage names to stage functions
+// globalRegistry is a global, default mapping of stage names to stage functions
 var globalRegistry = StageRegistry{
-	"reducehealth.standard":   ReduceSnakeHealthStandard,
-	"hazarddamage.standard":   DamageHazardsStandard,
-	"eatfood.standard":        FeedSnakesStandard,
-	"placefood.standard":      SpawnFoodStandard,
-	"placehazard.royale":      PopulateHazardsRoyale,
-	"removefood.constrictor":  RemoveFoodConstrictor,
-	"growsnake.constrictor":   GrowSnakesConstrictor,
-	"eliminatesnake.standard": EliminateSnakesStandard,
-	"movement.standard":       MoveSnakesStandard,
-	"movement.wrapped":        MoveSnakesWrapped,
-	"gameover.standard":       GameOverStandard,
-	"gameover.solo":           GameOverSolo,
-	"gameover.squad":          GameOverSquad,
-	"collision.squad":         ResurrectSnakesSquad,
-	"sharedattr.squad":        ShareAttributesSquad,
+	"food.remove.constrictor":  RemoveFoodConstrictor,
+	"food.spawn.standard":      SpawnFoodStandard,
+	"gameover.solo":            GameOverSolo,
+	"gameover.squad":           GameOverSquad,
+	"gameover.standard":        GameOverStandard,
+	"hazard.damage.standard":   DamageHazardsStandard,
+	"hazard.spawn.royale":      PopulateHazardsRoyale,
+	"health.reduce.standard":   ReduceSnakeHealthStandard,
+	"snake.collision.squad":    ResurrectSnakesSquad,
+	"snake.eatfood.standard":   FeedSnakesStandard,
+	"snake.eliminate.standard": EliminateSnakesStandard,
+	"snake.grow.constrictor":   GrowSnakesConstrictor,
+	"snake.movement.standard":  MoveSnakesStandard,
+	"snake.movement.wrapped":   MoveSnakesWrapped,
+	"snake.share.squad":        ShareAttributesSquad,
 }
 
 // RegisterPipelineStage adds a stage to the registry.

--- a/pipeline.go
+++ b/pipeline.go
@@ -1,0 +1,126 @@
+package rules
+
+import (
+	"errors"
+)
+
+// StageRegistry is a mapping of stage names to stage functions
+type StageRegistry map[string]StageFunc
+
+// globalRegistry is a global mapping of stage names to stage functions
+var globalRegistry = StageRegistry{}
+
+// RegisterPipelineStage adds a stage to the registry.
+// If a stage has already been mapped it will be overwritten by the newly
+// registered function.
+func (sr StageRegistry) RegisterPipelineStage(s string, fn StageFunc) {
+	sr[s] = fn
+}
+
+// RegisterPipelineStageError adds a stage to the registry.
+// If a stage has already been mapped an error will be returned.
+func (sr StageRegistry) RegisterPipelineStageError(s string, fn StageFunc) error {
+	if _, ok := sr[s]; ok {
+		return errors.New("stage has already been registered")
+	}
+
+	sr.RegisterPipelineStage(s, fn)
+	return nil
+}
+
+// RegisterPipelineStage adds a stage to the global stage registry.
+// If a stage has already been mapped it will be overwritten by the newly
+// registered function.
+func RegisterPipelineStage(s string, fn StageFunc) {
+	globalRegistry.RegisterPipelineStage(s, fn)
+}
+
+// RegisterPipelineStageError adds a stage to the global stage registry.
+// If a stage has already been mapped an error will be returned.
+func RegisterPipelineStageError(s string, fn StageFunc) error {
+	return globalRegistry.RegisterPipelineStageError(s, fn)
+}
+
+// Pipeline is an ordered sequences of game stages which are executed to produce the
+// next game state.
+//
+// If a stage produces an error or an ended game state, the pipeline is halted at that stage.
+type Pipeline struct {
+	// stages is a list of stages that should be executed from slice start to end
+	stages []StageFunc
+}
+
+// NewPipeline constructs an instance of Pipeline, which is a series of stages of
+// game behavior that are ordered in a particular sequence.
+//
+//
+// The order of execution for the pipeline stages will correspond to the order that
+// the stage names are provided.
+//
+// Example:
+// 	NewPipeline(s, "stage1", "stage2")
+// ... will result in stage "stage1" running first, then stage "stage2" running after.
+//
+// The stage names come from a global registry that maps names to stage functions.
+//
+// An error will be returned if an unregistered stage name is used (a name that is not
+// mapped in the registry).
+func NewPipeline(stageNames ...string) (*Pipeline, error) {
+	return NewPipelineFromRegistry(globalRegistry, stageNames...)
+}
+
+// NewPipelineFromRegistry constructs an instance of Pipeline, using the specified registry.
+//
+// The order of execution for the pipeline stages will correspond to the order that
+// the stage names are provided.
+//
+// Example:
+// 	NewPipelineFromRegistry(r, s, "stage1", "stage2")
+// ... will result in stage "stage1" running first, then stage "stage2" running after.
+//
+// An error will be returned if an unregistered stage name is used (a name that is not
+// mapped in the registry).
+func NewPipelineFromRegistry(registry map[string]StageFunc, stageNames ...string) (*Pipeline, error) {
+	// this can't be useful and probably indicates a problem
+	if len(registry) == 0 {
+		return nil, errors.New("empty registry")
+	}
+
+	// this also can't be useful and probably indicates a problem
+	if len(stageNames) == 0 {
+		return nil, errors.New("no stages")
+	}
+
+	p := &Pipeline{}
+	for _, s := range stageNames {
+		fn, ok := registry[s]
+		if !ok {
+			return nil, errors.New("stage not found")
+		}
+
+		p.stages = append(p.stages, fn)
+	}
+
+	return p, nil
+}
+
+// Execute runs all of the pipeline stages and produces a next game state.
+// If any stage produces an error or an ended game state, the pipeline
+// immediately stops at that stage.
+// The result is always the result of the last stage that was executed.
+func (p *Pipeline) Execute(state *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
+	var ended bool
+	var err error
+	for _, fn := range p.stages {
+		// execute current stage
+		ended, err = fn(state, settings, moves)
+
+		// stop if we hit any errors or if the game is ended
+		if err != nil || ended {
+			return ended, err
+		}
+	}
+
+	// return the result of the last stage as the final pipeline result
+	return ended, err
+}

--- a/pipeline.go
+++ b/pipeline.go
@@ -7,26 +7,45 @@ import (
 // StageRegistry is a mapping of stage names to stage functions
 type StageRegistry map[string]StageFunc
 
+const (
+	StageSpawnFoodStandard    = "spawn_food.standard"
+	StageGameOverStandard     = "game_over.standard"
+	StageStarvationStandard   = "starvation.standard"
+	StageFeedSnakesStandard   = "feed_snakes.standard"
+	StageMovementStandard     = "movement.standard"
+	StageHazardDamageStandard = "hazard_damage.standard"
+	StageEliminationStandard  = "elimination.standard"
+
+	StageGameOverSoloSnake                   = "game_over.solo_snake"
+	StageGameOverBySquad                     = "game_over.by_squad"
+	StageSpawnFoodNoFood                     = "spawn_food.no_food"
+	StageSpawnHazardsShrinkMap               = "spawn_hazards.shrink_map"
+	StageEliminationResurrectSquadCollisions = "elimination.resurrect_squad_collisions"
+	StageModifySnakesAlwaysGrow              = "modify_snakes.always_grow"
+	StageMovementWrapBoundaries              = "movement.wrap_boundaries"
+	StageModifySnakesShareAttributes         = "modify_snakes.share_attributes"
+)
+
 // globalRegistry is a global, default mapping of stage names to stage functions.
 // It can be extended by plugins through the use of registration functions.
 // Plugins that wish to extend the available game stages should call RegisterPipelineStageError
 // to add additional stages.
 var globalRegistry = StageRegistry{
-	"food.remove.constrictor":  RemoveFoodConstrictor,
-	"food.spawn.standard":      SpawnFoodStandard,
-	"gameover.solo":            GameOverSolo,
-	"gameover.squad":           GameOverSquad,
-	"gameover.standard":        GameOverStandard,
-	"hazard.damage.standard":   DamageHazardsStandard,
-	"hazard.spawn.royale":      PopulateHazardsRoyale,
-	"health.reduce.standard":   ReduceSnakeHealthStandard,
-	"snake.collision.squad":    ResurrectSnakesSquad,
-	"snake.eatfood.standard":   FeedSnakesStandard,
-	"snake.eliminate.standard": EliminateSnakesStandard,
-	"snake.grow.constrictor":   GrowSnakesConstrictor,
-	"snake.movement.standard":  MoveSnakesStandard,
-	"snake.movement.wrapped":   MoveSnakesWrapped,
-	"snake.share.squad":        ShareAttributesSquad,
+	StageSpawnFoodNoFood:                     RemoveFoodConstrictor,
+	StageSpawnFoodStandard:                   SpawnFoodStandard,
+	StageGameOverSoloSnake:                   GameOverSolo,
+	StageGameOverBySquad:                     GameOverSquad,
+	StageGameOverStandard:                    GameOverStandard,
+	StageHazardDamageStandard:                DamageHazardsStandard,
+	StageSpawnHazardsShrinkMap:               PopulateHazardsRoyale,
+	StageStarvationStandard:                  ReduceSnakeHealthStandard,
+	StageEliminationResurrectSquadCollisions: ResurrectSnakesSquad,
+	StageFeedSnakesStandard:                  FeedSnakesStandard,
+	StageEliminationStandard:                 EliminateSnakesStandard,
+	StageModifySnakesAlwaysGrow:              GrowSnakesConstrictor,
+	StageMovementStandard:                    MoveSnakesStandard,
+	StageMovementWrapBoundaries:              MoveSnakesWrapped,
+	StageModifySnakesShareAttributes:         ShareAttributesSquad,
 }
 
 // RegisterPipelineStage adds a stage to the registry.

--- a/pipeline.go
+++ b/pipeline.go
@@ -1,9 +1,6 @@
 package rules
 
-import (
-	"errors"
-	"fmt"
-)
+import "fmt"
 
 // StageRegistry is a mapping of stage names to stage functions
 type StageRegistry map[string]StageFunc
@@ -26,36 +23,6 @@ const (
 	StageMovementWrapBoundaries              = "movement.wrap_boundaries"
 	StageModifySnakesShareAttributes         = "modify_snakes.share_attributes"
 )
-
-var (
-	ErrorEmptyRegistry = errors.New("empty registry")
-	ErrorNoStages      = errors.New("no stages")
-	ErrorStageNotFound = errors.New("stage not found")
-)
-
-type duplicateStageError struct {
-	stage string
-}
-
-func (dse duplicateStageError) Error() string {
-	return fmt.Sprintf("stage '%s' has already been registered", dse.stage)
-}
-
-// IsDuplicate implements an interface that allows a check of whether the error is from
-// registering a duplicate pipeline stage.
-func (dse duplicateStageError) IsDuplicate() bool {
-	return true
-}
-
-// IsDuplicateStage provides a convenient way to check if an error was
-// because of a duplicate pipeline stage
-func IsDuplicateStage(err error) bool {
-	type isDuplicate interface {
-		IsDuplicate() bool
-	}
-	te, ok := err.(isDuplicate)
-	return ok && te.IsDuplicate()
-}
 
 // globalRegistry is a global, default mapping of stage names to stage functions.
 // It can be extended by plugins through the use of registration functions.
@@ -90,7 +57,7 @@ func (sr StageRegistry) RegisterPipelineStage(s string, fn StageFunc) {
 // If a stage has already been mapped an error will be returned.
 func (sr StageRegistry) RegisterPipelineStageError(s string, fn StageFunc) error {
 	if _, ok := sr[s]; ok {
-		return duplicateStageError{stage: s}
+		return RulesetError(fmt.Sprintf("stage '%s' has already been registered", s))
 	}
 
 	sr.RegisterPipelineStage(s, fn)

--- a/pipeline.go
+++ b/pipeline.go
@@ -7,23 +7,26 @@ import (
 // StageRegistry is a mapping of stage names to stage functions
 type StageRegistry map[string]StageFunc
 
-// globalRegistry is a global, default mapping of stage names to stage functions
+// globalRegistry is a global, default mapping of stage names to stage functions.
+// It can be extended by plugins through the use of registration functions.
+// Plugins that wish to extend the available game stages should call RegisterPipelineStageError
+// to add additional stages.
 var globalRegistry = StageRegistry{
 	"food.remove.constrictor":  RemoveFoodConstrictor,
-	"food.spawn.standard":      SpawnFoodStandard,
-	"gameover.solo":            GameOverSolo,
-	"gameover.squad":           GameOverSquad,
-	"gameover.standard":        GameOverStandard,
-	"hazard.damage.standard":   DamageHazardsStandard,
-	"hazard.spawn.royale":      PopulateHazardsRoyale,
-	"health.reduce.standard":   ReduceSnakeHealthStandard,
-	"snake.collision.squad":    ResurrectSnakesSquad,
-	"snake.eatfood.standard":   FeedSnakesStandard,
-	"snake.eliminate.standard": EliminateSnakesStandard,
+	"food.spawn.standard":      WithNoOpOnInit(SpawnFoodStandard),
+	"gameover.solo":            WithNoOpOnInit(GameOverSolo),
+	"gameover.squad":           WithNoOpOnInit(GameOverSquad),
+	"gameover.standard":        WithNoOpOnInit(GameOverStandard),
+	"hazard.damage.standard":   WithNoOpOnInit(DamageHazardsStandard),
+	"hazard.spawn.royale":      WithNoOpOnInit(PopulateHazardsRoyale),
+	"health.reduce.standard":   WithNoOpOnInit(ReduceSnakeHealthStandard),
+	"snake.collision.squad":    WithNoOpOnInit(ResurrectSnakesSquad),
+	"snake.eatfood.standard":   WithNoOpOnInit(FeedSnakesStandard),
+	"snake.eliminate.standard": WithNoOpOnInit(EliminateSnakesStandard),
 	"snake.grow.constrictor":   GrowSnakesConstrictor,
-	"snake.movement.standard":  MoveSnakesStandard,
-	"snake.movement.wrapped":   MoveSnakesWrapped,
-	"snake.share.squad":        ShareAttributesSquad,
+	"snake.movement.standard":  WithNoOpOnInit(MoveSnakesStandard),
+	"snake.movement.wrapped":   WithNoOpOnInit(MoveSnakesWrapped),
+	"snake.share.squad":        WithNoOpOnInit(ShareAttributesSquad),
 }
 
 // RegisterPipelineStage adds a stage to the registry.

--- a/pipeline.go
+++ b/pipeline.go
@@ -109,14 +109,6 @@ func NewPipelineFromRegistry(registry map[string]StageFunc, stageNames ...string
 	return p, nil
 }
 
-// Append appends the stages from another pipeline to the end of this pipeline.
-// It is similar to the standard append in that the backing slice of stages will be re-used, when possible.
-func (p *Pipeline) Append(p2 *Pipeline) *Pipeline {
-	return &Pipeline{
-		stages: append(p.stages, p2.stages...),
-	}
-}
-
 // Execute runs all of the pipeline stages and produces a next game state
 // by cloning the original state and applying stages to modify the cloned, next state.
 //

--- a/pipeline.go
+++ b/pipeline.go
@@ -67,16 +67,12 @@ func (sr StageRegistry) RegisterPipelineStageError(s string, fn StageFunc) error
 }
 
 // RegisterPipelineStage adds a stage to the global stage registry.
-// If a stage has already been mapped it will be overwritten by the newly
-// registered function.
+// It will panic if the a stage has already been registered with the same name.
 func RegisterPipelineStage(s string, fn StageFunc) {
-	globalRegistry.RegisterPipelineStage(s, fn)
-}
-
-// RegisterPipelineStageError adds a stage to the global stage registry.
-// If a stage has already been mapped an error will be returned.
-func RegisterPipelineStageError(s string, fn StageFunc) error {
-	return globalRegistry.RegisterPipelineStageError(s, fn)
+	err := globalRegistry.RegisterPipelineStageError(s, fn)
+	if err != nil {
+		panic(err)
+	}
 }
 
 // Pipeline is an ordered sequences of game stages which are executed to produce the

--- a/pipeline.go
+++ b/pipeline.go
@@ -92,6 +92,8 @@ type Pipeline interface {
 	// The result is the result of the last stage that was executed.
 	//
 	Execute(*BoardState, Settings, []SnakeMove) (bool, *BoardState, error)
+	// Error can be called to check if the pipeline is in an error state.
+	Error() error
 }
 
 // pipeline is an implementation of Pipeline
@@ -143,6 +145,11 @@ func NewPipelineFromRegistry(registry map[string]StageFunc, stageNames ...string
 	}
 
 	return &p
+}
+
+// impl
+func (p pipeline) Error() error {
+	return p.err
 }
 
 // impl

--- a/pipeline_internal_test.go
+++ b/pipeline_internal_test.go
@@ -6,6 +6,56 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestPipelineRuleset(t *testing.T) {
+	r := StageRegistry{
+		"doesnt_end": mockStageFn(false, nil),
+		"ends":       mockStageFn(true, nil),
+	}
+
+	// test game over when it does end
+	p := NewPipelineFromRegistry(r, "doesnt_end", "ends")
+	pr := pipelineRuleset{
+		name:     "test",
+		pipeline: p,
+	}
+	require.Equal(t, "test", pr.Name())
+	ended, err := pr.IsGameOver(&BoardState{})
+	require.NoError(t, err)
+	require.True(t, ended)
+
+	// Test game over when it doesn't end
+	p = NewPipelineFromRegistry(r, "doesnt_end")
+	pr = pipelineRuleset{
+		name:     "test",
+		pipeline: p,
+	}
+	ended, err = pr.IsGameOver(&BoardState{})
+	require.NoError(t, err)
+	require.False(t, ended)
+
+	// test a stage that adds food, except on initialization
+	r.RegisterPipelineStage("add_food", func(bs *BoardState, s Settings, sm []SnakeMove) (bool, error) {
+		if IsInitialisation(bs, s, sm) {
+			return false, nil
+		}
+		bs.Food = append(bs.Food, Point{X: 0, Y: 0})
+		return false, nil
+	})
+	b := &BoardState{}
+	p = NewPipelineFromRegistry(r, "add_food")
+	pr = pipelineRuleset{
+		name:     "test",
+		pipeline: p,
+	}
+	require.Empty(t, b.Food)
+	b, err = pr.ModifyInitialBoardState(b)
+	require.NoError(t, err)
+	require.Empty(t, b.Food, "food should not be added on initialisation phase")
+	b, err = pr.CreateNextBoardState(b, mockSnakeMoves())
+	require.NoError(t, err)
+	require.NotEmpty(t, b.Food, "fodo should be added now")
+}
+
 func TestPipelineGlboals(t *testing.T) {
 	oldReg := globalRegistry
 	globalRegistry = StageRegistry{}

--- a/pipeline_internal_test.go
+++ b/pipeline_internal_test.go
@@ -19,8 +19,7 @@ func TestPipelineGlboals(t *testing.T) {
 	require.NoError(t, RegisterPipelineStageError("other", mockStageFn(true, nil)))
 
 	// ensure that we can build a pipeline using the global registry
-	p, err := NewPipeline("test", "other")
-	require.NoError(t, err)
+	p := NewPipeline("test", "other")
 	require.NotNil(t, p)
 
 	// ensure that it runs okay too

--- a/pipeline_internal_test.go
+++ b/pipeline_internal_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,13 +13,21 @@ func TestPipelineRuleset(t *testing.T) {
 		"ends":       mockStageFn(true, nil),
 	}
 
-	// test game over when it does end
-	p := NewPipelineFromRegistry(r, "doesnt_end", "ends")
+	// Name/Error methods
+	p := NewPipelineFromRegistry(r, "404doesntexist")
 	pr := pipelineRuleset{
 		name:     "test",
 		pipeline: p,
 	}
 	require.Equal(t, "test", pr.Name())
+	require.Equal(t, errors.New("stage not found"), pr.Error())
+
+	// test game over when it does end
+	p = NewPipelineFromRegistry(r, "doesnt_end", "ends")
+	pr = pipelineRuleset{
+		name:     "test",
+		pipeline: p,
+	}
 	ended, err := pr.IsGameOver(&BoardState{})
 	require.NoError(t, err)
 	require.True(t, ended)

--- a/pipeline_internal_test.go
+++ b/pipeline_internal_test.go
@@ -1,7 +1,6 @@
 package rules
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,7 +19,7 @@ func TestPipelineRuleset(t *testing.T) {
 		pipeline: p,
 	}
 	require.Equal(t, "test", pr.Name())
-	require.Equal(t, errors.New("stage not found"), pr.Err())
+	require.Equal(t, ErrorStageNotFound, pr.Err())
 
 	// test game over when it does end
 	p = NewPipelineFromRegistry(r, "doesnt_end", "ends")

--- a/pipeline_internal_test.go
+++ b/pipeline_internal_test.go
@@ -65,17 +65,6 @@ func TestPipelineRuleset(t *testing.T) {
 	require.NotEmpty(t, b.Food, "fodo should be added now")
 }
 
-func assertPanic(t *testing.T, f func()) {
-	t.Helper()
-	defer func() {
-		t.Helper()
-		if r := recover(); r == nil {
-			t.Errorf("panic expected")
-		}
-	}()
-	f()
-}
-
 func TestPipelineGlobals(t *testing.T) {
 	oldReg := globalRegistry
 	globalRegistry = StageRegistry{}
@@ -85,7 +74,7 @@ func TestPipelineGlobals(t *testing.T) {
 	require.Contains(t, globalRegistry, "test")
 
 	// ensure that the global registry panics if you register an existing stage name
-	assertPanic(t, func() {
+	require.Panics(t, func() {
 		RegisterPipelineStage("test", mockStageFn(false, nil))
 	})
 	RegisterPipelineStage("other", mockStageFn(true, nil)) // otherwise should not panic

--- a/pipeline_internal_test.go
+++ b/pipeline_internal_test.go
@@ -24,8 +24,9 @@ func TestPipelineGlboals(t *testing.T) {
 	require.NotNil(t, p)
 
 	// ensure that it runs okay too
-	ended, err := p.Execute(nil, Settings{}, nil)
+	ended, next, err := p.Execute(&BoardState{}, Settings{}, nil)
 	require.NoError(t, err)
+	require.NotNil(t, next)
 	require.True(t, ended)
 
 	globalRegistry = oldReg

--- a/pipeline_internal_test.go
+++ b/pipeline_internal_test.go
@@ -20,7 +20,7 @@ func TestPipelineRuleset(t *testing.T) {
 		pipeline: p,
 	}
 	require.Equal(t, "test", pr.Name())
-	require.Equal(t, errors.New("stage not found"), pr.Error())
+	require.Equal(t, errors.New("stage not found"), pr.Err())
 
 	// test game over when it does end
 	p = NewPipelineFromRegistry(r, "doesnt_end", "ends")

--- a/pipeline_internal_test.go
+++ b/pipeline_internal_test.go
@@ -44,7 +44,7 @@ func TestPipelineRuleset(t *testing.T) {
 
 	// test a stage that adds food, except on initialization
 	r.RegisterPipelineStage("add_food", func(bs *BoardState, s Settings, sm []SnakeMove) (bool, error) {
-		if IsInitialisation(bs, s, sm) {
+		if IsInitialization(bs, s, sm) {
 			return false, nil
 		}
 		bs.Food = append(bs.Food, Point{X: 0, Y: 0})

--- a/pipeline_internal_test.go
+++ b/pipeline_internal_test.go
@@ -1,0 +1,38 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPipelineGlboals(t *testing.T) {
+	oldReg := globalRegistry
+	globalRegistry = StageRegistry{}
+
+	// ensure that we can register a function without errors
+	RegisterPipelineStage("test", mockStageFn(false, nil))
+	require.Contains(t, globalRegistry, "test")
+
+	// ensure that registry errors for existing stage names
+	require.Error(t, RegisterPipelineStageError("test", mockStageFn(false, nil)))
+	require.NoError(t, RegisterPipelineStageError("other", mockStageFn(true, nil)))
+
+	// ensure that we can build a pipeline using the global registry
+	p, err := NewPipeline("test", "other")
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	// ensure that it runs okay too
+	ended, err := p.Execute(nil, Settings{}, nil)
+	require.NoError(t, err)
+	require.True(t, ended)
+
+	globalRegistry = oldReg
+}
+
+func mockStageFn(ended bool, err error) StageFunc {
+	return func(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
+		return ended, err
+	}
+}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -66,9 +66,10 @@ func TestStageRegistry(t *testing.T) {
 	require.Contains(t, sr, "test")
 
 	// error on duplicate
+	var e rules.RulesetError
 	err := sr.RegisterPipelineStageError("test", mockStageFn(false, nil))
 	require.Error(t, err)
-	require.True(t, rules.IsDuplicateStage(err))
+	require.True(t, errors.As(err, &e), "error should be a RulesetError")
 	require.Equal(t, "stage 'test' has already been registered", err.Error())
 
 	// register another stage with no error

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -12,16 +12,22 @@ func TestPipeline(t *testing.T) {
 	r := rules.StageRegistry{}
 
 	// test empty registry error
-	_, _, err := rules.NewPipelineFromRegistry(r).Execute(nil, rules.Settings{}, nil)
+	p := rules.NewPipelineFromRegistry(r)
+	require.Equal(t, errors.New("empty registry"), p.Error())
+	_, _, err := p.Execute(nil, rules.Settings{}, nil)
 	require.Equal(t, errors.New("empty registry"), err)
 
 	// test empty stages names error
 	r.RegisterPipelineStage("astage", mockStageFn(false, nil))
-	_, _, err = rules.NewPipelineFromRegistry(r).Execute(&rules.BoardState{}, rules.Settings{}, nil)
+	p = rules.NewPipelineFromRegistry(r)
+	require.Equal(t, errors.New("no stages"), p.Error())
+	_, _, err = p.Execute(&rules.BoardState{}, rules.Settings{}, nil)
 	require.Equal(t, errors.New("no stages"), err)
 
 	// test that an unregistered stage name errors
-	_, _, err = rules.NewPipelineFromRegistry(r, "doesntexist").Execute(&rules.BoardState{}, rules.Settings{}, nil)
+	p = rules.NewPipelineFromRegistry(r, "doesntexist")
+	_, _, err = p.Execute(&rules.BoardState{}, rules.Settings{}, nil)
+	require.Equal(t, errors.New("stage not found"), p.Error())
 	require.Equal(t, errors.New("stage not found"), err)
 
 	// simplest case - one stage

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -28,44 +28,50 @@ func TestPipeline(t *testing.T) {
 	p, err := rules.NewPipelineFromRegistry(r, "astage")
 	require.NoError(t, err)
 	require.NotNil(t, p)
-	ended, err := p.Execute(nil, rules.Settings{}, nil)
+	ended, next, err := p.Execute(&rules.BoardState{}, rules.Settings{}, nil)
 	require.NoError(t, err)
+	require.NotNil(t, next)
 	require.False(t, ended)
 
 	// test that the pipeline short-circuits for a stage that errors
 	r.RegisterPipelineStage("errors", mockStageFn(false, errors.New("")))
 	p, err = rules.NewPipelineFromRegistry(r, "errors", "astage")
 	require.NoError(t, err)
-	ended, err = p.Execute(nil, rules.Settings{}, nil)
+	ended, next, err = p.Execute(&rules.BoardState{}, rules.Settings{}, nil)
 	require.Error(t, err)
+	require.NotNil(t, next)
 	require.False(t, ended)
 
 	// test that the pipeline short-circuits for a stage that ends
 	r.RegisterPipelineStage("ends", mockStageFn(true, nil))
 	p, err = rules.NewPipelineFromRegistry(r, "ends", "astage")
 	require.NoError(t, err)
-	ended, err = p.Execute(nil, rules.Settings{}, nil)
+	ended, next, err = p.Execute(&rules.BoardState{}, rules.Settings{}, nil)
 	require.NoError(t, err)
+	require.NotNil(t, next)
 	require.True(t, ended)
 
 	// test that the pipeline runs normally for multiple stages
 	p, err = rules.NewPipelineFromRegistry(r, "astage", "ends")
 	require.NoError(t, err)
-	ended, err = p.Execute(nil, rules.Settings{}, nil)
+	ended, next, err = p.Execute(&rules.BoardState{}, rules.Settings{}, nil)
 	require.NoError(t, err)
+	require.NotNil(t, next)
 	require.True(t, ended)
 
 	// test that Append works
 	p, err = rules.NewPipelineFromRegistry(r, "astage")
 	require.NoError(t, err)
-	ended, err = p.Execute(nil, rules.Settings{}, nil)
+	ended, next, err = p.Execute(&rules.BoardState{}, rules.Settings{}, nil)
 	require.NoError(t, err)
+	require.NotNil(t, next)
 	require.False(t, ended) // current pipeline shouldn't end
 	p2, err := rules.NewPipelineFromRegistry(r, "ends")
 	require.NoError(t, err)
 	p = p.Append(p2)
-	ended, err = p.Execute(nil, rules.Settings{}, nil)
+	ended, next, err = p.Execute(&rules.BoardState{}, rules.Settings{}, nil)
 	require.NoError(t, err)
+	require.NotNil(t, next)
 	require.True(t, ended) // now the pipeline should end since we appended a pipeline that does end
 }
 

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -54,6 +54,19 @@ func TestPipeline(t *testing.T) {
 	ended, err = p.Execute(nil, rules.Settings{}, nil)
 	require.NoError(t, err)
 	require.True(t, ended)
+
+	// test that Append works
+	p, err = rules.NewPipelineFromRegistry(r, "astage")
+	require.NoError(t, err)
+	ended, err = p.Execute(nil, rules.Settings{}, nil)
+	require.NoError(t, err)
+	require.False(t, ended) // current pipeline shouldn't end
+	p2, err := rules.NewPipelineFromRegistry(r, "ends")
+	require.NoError(t, err)
+	p = p.Append(p2)
+	ended, err = p.Execute(nil, rules.Settings{}, nil)
+	require.NoError(t, err)
+	require.True(t, ended) // now the pipeline should end since we appended a pipeline that does end
 }
 
 func TestStageRegistry(t *testing.T) {

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -58,21 +58,6 @@ func TestPipeline(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, next)
 	require.True(t, ended)
-
-	// test that Append works
-	p, err = rules.NewPipelineFromRegistry(r, "astage")
-	require.NoError(t, err)
-	ended, next, err = p.Execute(&rules.BoardState{}, rules.Settings{}, nil)
-	require.NoError(t, err)
-	require.NotNil(t, next)
-	require.False(t, ended) // current pipeline shouldn't end
-	p2, err := rules.NewPipelineFromRegistry(r, "ends")
-	require.NoError(t, err)
-	p = p.Append(p2)
-	ended, next, err = p.Execute(&rules.BoardState{}, rules.Settings{}, nil)
-	require.NoError(t, err)
-	require.NotNil(t, next)
-	require.True(t, ended) // now the pipeline should end since we appended a pipeline that does end
 }
 
 func TestStageRegistry(t *testing.T) {

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -13,21 +13,21 @@ func TestPipeline(t *testing.T) {
 
 	// test empty registry error
 	p := rules.NewPipelineFromRegistry(r)
-	require.Equal(t, errors.New("empty registry"), p.Error())
+	require.Equal(t, errors.New("empty registry"), p.Err())
 	_, _, err := p.Execute(nil, rules.Settings{}, nil)
 	require.Equal(t, errors.New("empty registry"), err)
 
 	// test empty stages names error
 	r.RegisterPipelineStage("astage", mockStageFn(false, nil))
 	p = rules.NewPipelineFromRegistry(r)
-	require.Equal(t, errors.New("no stages"), p.Error())
+	require.Equal(t, errors.New("no stages"), p.Err())
 	_, _, err = p.Execute(&rules.BoardState{}, rules.Settings{}, nil)
 	require.Equal(t, errors.New("no stages"), err)
 
 	// test that an unregistered stage name errors
 	p = rules.NewPipelineFromRegistry(r, "doesntexist")
 	_, _, err = p.Execute(&rules.BoardState{}, rules.Settings{}, nil)
-	require.Equal(t, errors.New("stage not found"), p.Error())
+	require.Equal(t, errors.New("stage not found"), p.Err())
 	require.Equal(t, errors.New("stage not found"), err)
 
 	// simplest case - one stage

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -1,0 +1,85 @@
+package rules_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/BattlesnakeOfficial/rules"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPipeline(t *testing.T) {
+	r := rules.StageRegistry{}
+
+	// test empty registry error
+	_, err := rules.NewPipelineFromRegistry(r)
+	require.Equal(t, errors.New("empty registry"), err)
+
+	// test empty stages names error
+	r.RegisterPipelineStage("astage", mockStageFn(false, nil))
+	_, err = rules.NewPipelineFromRegistry(r)
+	require.Equal(t, errors.New("no stages"), err)
+
+	// test that an unregistered stage name errors
+	_, err = rules.NewPipelineFromRegistry(r, "doesntexist")
+	require.Equal(t, errors.New("stage not found"), err)
+
+	// simplest case - one stage
+	p, err := rules.NewPipelineFromRegistry(r, "astage")
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	ended, err := p.Execute(nil, rules.Settings{}, nil)
+	require.NoError(t, err)
+	require.False(t, ended)
+
+	// test that the pipeline short-circuits for a stage that errors
+	r.RegisterPipelineStage("errors", mockStageFn(false, errors.New("")))
+	p, err = rules.NewPipelineFromRegistry(r, "errors", "astage")
+	require.NoError(t, err)
+	ended, err = p.Execute(nil, rules.Settings{}, nil)
+	require.Error(t, err)
+	require.False(t, ended)
+
+	// test that the pipeline short-circuits for a stage that ends
+	r.RegisterPipelineStage("ends", mockStageFn(true, nil))
+	p, err = rules.NewPipelineFromRegistry(r, "ends", "astage")
+	require.NoError(t, err)
+	ended, err = p.Execute(nil, rules.Settings{}, nil)
+	require.NoError(t, err)
+	require.True(t, ended)
+
+	// test that the pipeline runs normally for multiple stages
+	p, err = rules.NewPipelineFromRegistry(r, "astage", "ends")
+	require.NoError(t, err)
+	ended, err = p.Execute(nil, rules.Settings{}, nil)
+	require.NoError(t, err)
+	require.True(t, ended)
+}
+
+func TestStageRegistry(t *testing.T) {
+	sr := rules.StageRegistry{}
+
+	// register a stage without error
+	require.NoError(t, sr.RegisterPipelineStageError("test", mockStageFn(false, nil)))
+	require.Contains(t, sr, "test")
+
+	// error on duplicate
+	require.Error(t, sr.RegisterPipelineStageError("test", mockStageFn(false, nil)))
+
+	// register another stage with no error
+	require.NoError(t, sr.RegisterPipelineStageError("other", mockStageFn(false, nil)))
+	require.Contains(t, sr, "other")
+
+	// register stage
+	sr.RegisterPipelineStage("last", mockStageFn(false, nil))
+	require.Contains(t, sr, "last")
+
+	// register existing stage (should just be okay and not panic or anything)
+	sr.RegisterPipelineStage("test", mockStageFn(false, nil))
+}
+
+func mockStageFn(ended bool, err error) rules.StageFunc {
+	return func(b *rules.BoardState, settings rules.Settings, moves []rules.SnakeMove) (bool, error) {
+		return ended, err
+	}
+}

--- a/royale.go
+++ b/royale.go
@@ -44,11 +44,6 @@ func (r *RoyaleRuleset) CreateNextBoardState(prevState *BoardState, moves []Snak
 	return nextState, err
 }
 
-func (r *RoyaleRuleset) populateHazards(b *BoardState) error {
-	_, err := r.callStageFunc(PopulateHazardsRoyale, b, []SnakeMove{})
-	return err
-}
-
 func PopulateHazardsRoyale(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
 	b.Hazards = []Point{}
 
@@ -99,9 +94,4 @@ func (r RoyaleRuleset) Settings() Settings {
 		ShrinkEveryNTurns: r.ShrinkEveryNTurns,
 	}
 	return s
-}
-
-// Adaptor for integrating stages into RoyaleRuleset
-func (r *RoyaleRuleset) callStageFunc(stage StageFunc, boardState *BoardState, moves []SnakeMove) (bool, error) {
-	return stage(boardState, r.Settings(), moves)
 }

--- a/royale.go
+++ b/royale.go
@@ -16,7 +16,7 @@ type RoyaleRuleset struct {
 func (r *RoyaleRuleset) Name() string { return GameTypeRoyale }
 
 func (r RoyaleRuleset) Pipeline() (*Pipeline, error) {
-	// The squad pipeline extends the standard pipeline
+	// The royale pipeline extends the standard pipeline
 	standard, err := r.StandardRuleset.Pipeline()
 	if err != nil {
 		return nil, err

--- a/royale.go
+++ b/royale.go
@@ -6,14 +6,14 @@ import (
 )
 
 var royaleRulesetStages = []string{
-	"snake.movement.standard",
-	"health.reduce.standard",
-	"hazard.damage.standard",
-	"snake.eatfood.standard",
-	"food.spawn.standard",
-	"snake.eliminate.standard",
-	"hazard.spawn.royale",
-	"gameover.standard",
+	StageMovementStandard,
+	StageStarvationStandard,
+	StageHazardDamageStandard,
+	StageFeedSnakesStandard,
+	StageSpawnFoodStandard,
+	StageEliminationStandard,
+	StageSpawnHazardsShrinkMap,
+	StageGameOverStandard,
 }
 
 type RoyaleRuleset struct {

--- a/royale.go
+++ b/royale.go
@@ -16,19 +16,16 @@ type RoyaleRuleset struct {
 func (r *RoyaleRuleset) Name() string { return GameTypeRoyale }
 
 func (r RoyaleRuleset) Pipeline() (*Pipeline, error) {
-	// The royale pipeline extends the standard pipeline
-	standard, err := r.StandardRuleset.Pipeline()
-	if err != nil {
-		return nil, err
-	}
-
-	royale, err := NewPipeline(
+	return NewPipeline(
+		"movement.standard",
+		"reducehealth.standard",
+		"hazarddamage.standard",
+		"eatfood.standard",
+		"placefood.standard",
+		"eliminatesnake.standard",
 		"placehazard.royale",
+		"gameover.standard",
 	)
-	if err != nil {
-		return nil, err
-	}
-	return standard.Append(royale), nil
 }
 
 func (r *RoyaleRuleset) CreateNextBoardState(prevState *BoardState, moves []SnakeMove) (*BoardState, error) {

--- a/royale.go
+++ b/royale.go
@@ -33,13 +33,11 @@ func (r *RoyaleRuleset) CreateNextBoardState(prevState *BoardState, moves []Snak
 		return nil, errors.New("royale damage per turn must be greater than zero")
 	}
 
-	nextState := prevState.Clone()
-
 	p, err := r.Pipeline()
 	if err != nil {
 		return nil, err
 	}
-	_, err = p.Execute(nextState, r.Settings(), moves)
+	_, nextState, err := p.Execute(prevState, r.Settings(), moves)
 
 	return nextState, err
 }

--- a/royale.go
+++ b/royale.go
@@ -43,6 +43,9 @@ func (r *RoyaleRuleset) CreateNextBoardState(prevState *BoardState, moves []Snak
 }
 
 func PopulateHazardsRoyale(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
+	if IsInitialisation(b, settings, moves) {
+		return false, nil
+	}
 	b.Hazards = []Point{}
 
 	// Royale uses the current turn to generate hazards, not the previous turn that's in the board state

--- a/royale.go
+++ b/royale.go
@@ -17,13 +17,13 @@ func (r *RoyaleRuleset) Name() string { return GameTypeRoyale }
 
 func (r RoyaleRuleset) Pipeline() (*Pipeline, error) {
 	return NewPipeline(
-		"movement.standard",
-		"reducehealth.standard",
-		"hazarddamage.standard",
-		"eatfood.standard",
-		"placefood.standard",
-		"eliminatesnake.standard",
-		"placehazard.royale",
+		"snake.movement.standard",
+		"health.reduce.standard",
+		"hazard.damage.standard",
+		"snake.eatfood.standard",
+		"food.spawn.standard",
+		"snake.eliminate.standard",
+		"hazard.spawn.royale",
 		"gameover.standard",
 	)
 }

--- a/royale.go
+++ b/royale.go
@@ -84,6 +84,11 @@ func PopulateHazardsRoyale(b *BoardState, settings Settings, moves []SnakeMove) 
 	return false, nil
 }
 
+func (r *RoyaleRuleset) IsGameOver(b *BoardState) (bool, error) {
+	gameover, _, err := r.Execute(b, r.Settings(), nil)
+	return gameover, err
+}
+
 func (r RoyaleRuleset) Settings() Settings {
 	s := r.StandardRuleset.Settings()
 	s.RoyaleSettings = RoyaleSettings{

--- a/royale.go
+++ b/royale.go
@@ -39,7 +39,7 @@ func (r *RoyaleRuleset) CreateNextBoardState(prevState *BoardState, moves []Snak
 }
 
 func PopulateHazardsRoyale(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
-	if IsInitialisation(b, settings, moves) {
+	if IsInitialization(b, settings, moves) {
 		return false, nil
 	}
 	b.Hazards = []Point{}

--- a/royale.go
+++ b/royale.go
@@ -5,6 +5,17 @@ import (
 	"math/rand"
 )
 
+var royaleRulesetStages = []string{
+	"snake.movement.standard",
+	"health.reduce.standard",
+	"hazard.damage.standard",
+	"snake.eatfood.standard",
+	"food.spawn.standard",
+	"snake.eliminate.standard",
+	"hazard.spawn.royale",
+	"gameover.standard",
+}
+
 type RoyaleRuleset struct {
 	StandardRuleset
 
@@ -15,30 +26,15 @@ type RoyaleRuleset struct {
 
 func (r *RoyaleRuleset) Name() string { return GameTypeRoyale }
 
-func (r RoyaleRuleset) Pipeline() (*Pipeline, error) {
-	return NewPipeline(
-		"snake.movement.standard",
-		"health.reduce.standard",
-		"hazard.damage.standard",
-		"snake.eatfood.standard",
-		"food.spawn.standard",
-		"snake.eliminate.standard",
-		"hazard.spawn.royale",
-		"gameover.standard",
-	)
+func (r RoyaleRuleset) Execute(bs *BoardState, s Settings, sm []SnakeMove) (bool, *BoardState, error) {
+	return NewPipeline(royaleRulesetStages...).Execute(bs, s, sm)
 }
 
 func (r *RoyaleRuleset) CreateNextBoardState(prevState *BoardState, moves []SnakeMove) (*BoardState, error) {
 	if r.StandardRuleset.HazardDamagePerTurn < 1 {
 		return nil, errors.New("royale damage per turn must be greater than zero")
 	}
-
-	p, err := r.Pipeline()
-	if err != nil {
-		return nil, err
-	}
-	_, nextState, err := p.Execute(prevState, r.Settings(), moves)
-
+	_, nextState, err := r.Execute(prevState, r.Settings(), moves)
 	return nextState, err
 }
 

--- a/royale.go
+++ b/royale.go
@@ -85,8 +85,7 @@ func PopulateHazardsRoyale(b *BoardState, settings Settings, moves []SnakeMove) 
 }
 
 func (r *RoyaleRuleset) IsGameOver(b *BoardState) (bool, error) {
-	gameover, _, err := r.Execute(b, r.Settings(), nil)
-	return gameover, err
+	return GameOverStandard(b, r.Settings(), nil)
 }
 
 func (r RoyaleRuleset) Settings() Settings {

--- a/royale_test.go
+++ b/royale_test.go
@@ -102,7 +102,7 @@ func TestRoyaleHazards(t *testing.T) {
 			ShrinkEveryNTurns: test.ShrinkEveryNTurns,
 		}
 
-		err := r.populateHazards(b)
+		_, err := PopulateHazardsRoyale(b, r.Settings(), nil)
 		require.Equal(t, test.Error, err)
 		if err == nil {
 			// Obstacles should match
@@ -131,7 +131,7 @@ func TestRoyalDamageNextTurn(t *testing.T) {
 	stateAfterTurn := func(prevState *BoardState, turn int32) *BoardState {
 		nextState := prevState.Clone()
 		nextState.Turn = turn - 1
-		err := r.populateHazards(nextState)
+		_, err := PopulateHazardsRoyale(nextState, r.Settings(), nil)
 		require.NoError(t, err)
 		nextState.Turn = turn
 		return nextState

--- a/royale_test.go
+++ b/royale_test.go
@@ -265,7 +265,16 @@ func TestRoyaleCreateNextBoardState(t *testing.T) {
 		ShrinkEveryNTurns: 1,
 	}
 	rand.Seed(0)
+	rb := NewRulesetBuilder().WithParams(map[string]string{
+		ParamGameType:            GameTypeRoyale,
+		ParamHazardDamagePerTurn: "1",
+		ParamShrinkEveryNTurns:   "1",
+	})
 	for _, gc := range cases {
 		gc.requireValidNextState(t, &r)
+		// also test a RulesBuilder constructed instance
+		gc.requireValidNextState(t, rb.Ruleset())
+		// also test a pipeline with the same settings
+		gc.requireValidNextState(t, rb.PipelineRuleset(GameTypeRoyale, NewPipeline(royaleRulesetStages...)))
 	}
 }

--- a/royale_test.go
+++ b/royale_test.go
@@ -15,7 +15,7 @@ func TestRoyaleRulesetInterface(t *testing.T) {
 func TestRoyaleDefaultSanity(t *testing.T) {
 	boardState := &BoardState{}
 	r := RoyaleRuleset{StandardRuleset: StandardRuleset{HazardDamagePerTurn: 1}, ShrinkEveryNTurns: 0}
-	_, err := r.CreateNextBoardState(boardState, []SnakeMove{})
+	_, err := r.CreateNextBoardState(boardState, []SnakeMove{{"", ""}})
 	require.Error(t, err)
 	require.Equal(t, errors.New("royale game can't shrink more frequently than every turn"), err)
 

--- a/royale_test.go
+++ b/royale_test.go
@@ -102,7 +102,7 @@ func TestRoyaleHazards(t *testing.T) {
 			ShrinkEveryNTurns: test.ShrinkEveryNTurns,
 		}
 
-		_, err := PopulateHazardsRoyale(b, r.Settings(), nil)
+		_, err := PopulateHazardsRoyale(b, r.Settings(), mockSnakeMoves())
 		require.Equal(t, test.Error, err)
 		if err == nil {
 			// Obstacles should match

--- a/ruleset.go
+++ b/ruleset.go
@@ -297,8 +297,12 @@ func (r pipelineRuleset) Settings() Settings {
 func (r pipelineRuleset) Name() string { return r.name }
 
 // impl Ruleset
+// IMPORTANT: this implementation of IsGameOver deviates from the previous Ruleset implementations
+// in that it checks if the *NEXT* state results in game over, not the previous state.
+// This is due to the design of pipelines / stage functions not having a distinction between
+// checking for game over and producing a next state.
 func (r *pipelineRuleset) IsGameOver(b *BoardState) (bool, error) {
-	gameover, _, err := r.Execute(b, r.Settings(), nil)
+	gameover, _, err := r.Execute(b, r.Settings(), nil) // checks if next state is game over
 	return gameover, err
 }
 

--- a/ruleset.go
+++ b/ruleset.go
@@ -285,27 +285,38 @@ type pipelineRuleset struct {
 	settings Settings
 }
 
+// impl Ruleset
 func (r pipelineRuleset) Settings() Settings {
 	return r.settings
 }
 
+// impl Ruleset
 func (r pipelineRuleset) Name() string { return r.name }
 
+// impl Ruleset
 func (r *pipelineRuleset) IsGameOver(b *BoardState) (bool, error) {
 	gameover, _, err := r.Execute(b, r.Settings(), nil)
 	return gameover, err
 }
 
+// impl Ruleset
 func (r pipelineRuleset) ModifyInitialBoardState(initialState *BoardState) (*BoardState, error) {
 	_, nextState, err := r.Execute(initialState, r.Settings(), nil)
 	return nextState, err
 }
 
+// impl Pipeline
 func (r pipelineRuleset) Execute(bs *BoardState, s Settings, sm []SnakeMove) (bool, *BoardState, error) {
 	return r.pipeline.Execute(bs, s, sm)
 }
 
+// impl Ruleset
 func (r pipelineRuleset) CreateNextBoardState(bs *BoardState, sm []SnakeMove) (*BoardState, error) {
 	_, nextState, err := r.Execute(bs, r.Settings(), sm)
 	return nextState, err
+}
+
+// impl Pipeline
+func (r pipelineRuleset) Error() error {
+	return r.pipeline.Error()
 }

--- a/ruleset.go
+++ b/ruleset.go
@@ -317,6 +317,6 @@ func (r pipelineRuleset) CreateNextBoardState(bs *BoardState, sm []SnakeMove) (*
 }
 
 // impl Pipeline
-func (r pipelineRuleset) Error() error {
-	return r.pipeline.Error()
+func (r pipelineRuleset) Err() error {
+	return r.pipeline.Err()
 }

--- a/ruleset.go
+++ b/ruleset.go
@@ -36,6 +36,9 @@ const (
 	ErrorNoRoomForFood   = RulesetError("not enough space to place food")
 	ErrorNoMoveFound     = RulesetError("move not provided for snake")
 	ErrorZeroLengthSnake = RulesetError("snake is length zero")
+	ErrorEmptyRegistry   = RulesetError("empty registry")
+	ErrorNoStages        = RulesetError("no stages")
+	ErrorStageNotFound   = RulesetError("stage not found")
 
 	// Ruleset / game type names
 	GameTypeConstrictor = "constrictor"

--- a/solo.go
+++ b/solo.go
@@ -1,13 +1,13 @@
 package rules
 
 var soloRulesetStages = []string{
-	"snake.movement.standard",
-	"health.reduce.standard",
-	"hazard.damage.standard",
-	"snake.eatfood.standard",
-	"food.spawn.standard",
-	"snake.eliminate.standard",
-	"gameover.solo",
+	StageMovementStandard,
+	StageStarvationStandard,
+	StageHazardDamageStandard,
+	StageFeedSnakesStandard,
+	StageSpawnFoodStandard,
+	StageEliminationStandard,
+	StageGameOverSoloSnake,
 }
 
 type SoloRuleset struct {

--- a/solo.go
+++ b/solo.go
@@ -23,9 +23,6 @@ func (r *SoloRuleset) IsGameOver(b *BoardState) (bool, error) {
 }
 
 func GameOverSolo(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
-	if IsInitialisation(b, settings, moves) {
-		return false, nil
-	}
 	for i := 0; i < len(b.Snakes); i++ {
 		if b.Snakes[i].EliminatedCause == NotEliminated {
 			return false, nil

--- a/solo.go
+++ b/solo.go
@@ -6,6 +6,18 @@ type SoloRuleset struct {
 
 func (r *SoloRuleset) Name() string { return GameTypeSolo }
 
+func (r SoloRuleset) Pipeline() (*Pipeline, error) {
+	return NewPipeline(
+		"movement.standard",
+		"reducehealth.standard",
+		"hazarddamage.standard",
+		"eatfood.standard",
+		"placefood.standard",
+		"eliminatesnake.standard",
+		"gameover.solo",
+	)
+}
+
 func (r *SoloRuleset) IsGameOver(b *BoardState) (bool, error) {
 	return r.callStageFunc(GameOverSolo, b, []SnakeMove{})
 }

--- a/solo.go
+++ b/solo.go
@@ -23,6 +23,9 @@ func (r *SoloRuleset) IsGameOver(b *BoardState) (bool, error) {
 }
 
 func GameOverSolo(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
+	if IsInitialisation(b, settings, moves) {
+		return false, nil
+	}
 	for i := 0; i < len(b.Snakes); i++ {
 		if b.Snakes[i].EliminatedCause == NotEliminated {
 			return false, nil

--- a/solo.go
+++ b/solo.go
@@ -21,8 +21,7 @@ func (r SoloRuleset) Execute(bs *BoardState, s Settings, sm []SnakeMove) (bool, 
 }
 
 func (r *SoloRuleset) IsGameOver(b *BoardState) (bool, error) {
-	gameover, _, err := r.Execute(b, r.Settings(), nil)
-	return gameover, err
+	return GameOverSolo(b, r.Settings(), nil)
 }
 
 func GameOverSolo(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {

--- a/solo.go
+++ b/solo.go
@@ -1,25 +1,28 @@
 package rules
 
+var soloRulesetStages = []string{
+	"snake.movement.standard",
+	"health.reduce.standard",
+	"hazard.damage.standard",
+	"snake.eatfood.standard",
+	"food.spawn.standard",
+	"snake.eliminate.standard",
+	"gameover.solo",
+}
+
 type SoloRuleset struct {
 	StandardRuleset
 }
 
 func (r *SoloRuleset) Name() string { return GameTypeSolo }
 
-func (r SoloRuleset) Pipeline() (*Pipeline, error) {
-	return NewPipeline(
-		"snake.movement.standard",
-		"health.reduce.standard",
-		"hazard.damage.standard",
-		"snake.eatfood.standard",
-		"food.spawn.standard",
-		"snake.eliminate.standard",
-		"gameover.solo",
-	)
+func (r SoloRuleset) Execute(bs *BoardState, s Settings, sm []SnakeMove) (bool, *BoardState, error) {
+	return NewPipeline(soloRulesetStages...).Execute(bs, s, sm)
 }
 
 func (r *SoloRuleset) IsGameOver(b *BoardState) (bool, error) {
-	return r.callStageFunc(GameOverSolo, b, []SnakeMove{})
+	gameover, _, err := r.Execute(b, r.Settings(), nil)
+	return gameover, err
 }
 
 func GameOverSolo(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {

--- a/solo.go
+++ b/solo.go
@@ -8,12 +8,12 @@ func (r *SoloRuleset) Name() string { return GameTypeSolo }
 
 func (r SoloRuleset) Pipeline() (*Pipeline, error) {
 	return NewPipeline(
-		"movement.standard",
-		"reducehealth.standard",
-		"hazarddamage.standard",
-		"eatfood.standard",
-		"placefood.standard",
-		"eliminatesnake.standard",
+		"snake.movement.standard",
+		"health.reduce.standard",
+		"hazard.damage.standard",
+		"snake.eatfood.standard",
+		"food.spawn.standard",
+		"snake.eliminate.standard",
 		"gameover.solo",
 	)
 }

--- a/solo_test.go
+++ b/solo_test.go
@@ -44,6 +44,7 @@ func TestSoloIsGameOver(t *testing.T) {
 	r := SoloRuleset{}
 	for _, test := range tests {
 		b := &BoardState{
+			Turn:   99, // game can't end at 0, must be > 0 to end
 			Height: 11,
 			Width:  11,
 			Snakes: test.Snakes,

--- a/solo_test.go
+++ b/solo_test.go
@@ -105,7 +105,14 @@ func TestSoloCreateNextBoardState(t *testing.T) {
 		soloCaseNotOver,
 	}
 	r := SoloRuleset{}
+	rb := NewRulesetBuilder().WithParams(map[string]string{
+		ParamGameType: GameTypeSolo,
+	})
 	for _, gc := range cases {
 		gc.requireValidNextState(t, &r)
+		// also test a RulesBuilder constructed instance
+		gc.requireValidNextState(t, rb.Ruleset())
+		// also test a pipeline with the same settings
+		gc.requireValidNextState(t, NewRulesetBuilder().PipelineRuleset(GameTypeSolo, NewPipeline(soloRulesetStages...)))
 	}
 }

--- a/solo_test.go
+++ b/solo_test.go
@@ -44,7 +44,6 @@ func TestSoloIsGameOver(t *testing.T) {
 	r := SoloRuleset{}
 	for _, test := range tests {
 		b := &BoardState{
-			Turn:   99, // game can't end at 0, must be > 0 to end
 			Height: 11,
 			Width:  11,
 			Snakes: test.Snakes,

--- a/squad.go
+++ b/squad.go
@@ -20,14 +20,14 @@ func (r *SquadRuleset) Name() string { return GameTypeSquad }
 
 func (r SquadRuleset) Pipeline() (*Pipeline, error) {
 	return NewPipeline(
-		"movement.standard",
-		"reducehealth.standard",
-		"hazarddamage.standard",
-		"eatfood.standard",
-		"placefood.standard",
-		"eliminatesnake.standard",
-		"collision.squad",
-		"sharedattr.squad",
+		"snake.movement.standard",
+		"health.reduce.standard",
+		"hazard.damage.standard",
+		"snake.eatfood.standard",
+		"food.spawn.standard",
+		"snake.eliminate.standard",
+		"snake.collision.squad",
+		"snake.share.squad",
 		"gameover.squad",
 	)
 }

--- a/squad.go
+++ b/squad.go
@@ -52,11 +52,6 @@ func areSnakeIDsOnSameSquad(squadMap map[string]string, snakeID string, otherID 
 	return squadMap[snakeID] == squadMap[otherID]
 }
 
-func (r *SquadRuleset) resurrectSquadBodyCollisions(b *BoardState) error {
-	_, err := r.callStageFunc(ResurrectSnakesSquad, b, []SnakeMove{})
-	return err
-}
-
 func ResurrectSnakesSquad(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
 	if !settings.SquadSettings.AllowBodyCollisions {
 		return false, nil
@@ -76,11 +71,6 @@ func ResurrectSnakesSquad(b *BoardState, settings Settings, moves []SnakeMove) (
 	}
 
 	return false, nil
-}
-
-func (r *SquadRuleset) shareSquadAttributes(b *BoardState) error {
-	_, err := r.callStageFunc(ShareAttributesSquad, b, []SnakeMove{})
-	return err
 }
 
 func ShareAttributesSquad(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {

--- a/squad.go
+++ b/squad.go
@@ -51,6 +51,9 @@ func areSnakeIDsOnSameSquad(squadMap map[string]string, snakeID string, otherID 
 }
 
 func ResurrectSnakesSquad(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
+	if IsInitialisation(b, settings, moves) {
+		return false, nil
+	}
 	if !settings.SquadSettings.AllowBodyCollisions {
 		return false, nil
 	}
@@ -72,6 +75,9 @@ func ResurrectSnakesSquad(b *BoardState, settings Settings, moves []SnakeMove) (
 }
 
 func ShareAttributesSquad(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
+	if IsInitialisation(b, settings, moves) {
+		return false, nil
+	}
 	squadSettings := settings.SquadSettings
 
 	if !(squadSettings.SharedElimination || squadSettings.SharedLength || squadSettings.SharedHealth) {

--- a/squad.go
+++ b/squad.go
@@ -48,7 +48,7 @@ func areSnakeIDsOnSameSquad(squadMap map[string]string, snakeID string, otherID 
 }
 
 func ResurrectSnakesSquad(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
-	if IsInitialisation(b, settings, moves) {
+	if IsInitialization(b, settings, moves) {
 		return false, nil
 	}
 	if !settings.SquadSettings.AllowBodyCollisions {
@@ -72,7 +72,7 @@ func ResurrectSnakesSquad(b *BoardState, settings Settings, moves []SnakeMove) (
 }
 
 func ShareAttributesSquad(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
-	if IsInitialisation(b, settings, moves) {
+	if IsInitialization(b, settings, moves) {
 		return false, nil
 	}
 	squadSettings := settings.SquadSettings

--- a/squad.go
+++ b/squad.go
@@ -118,8 +118,7 @@ func ShareAttributesSquad(b *BoardState, settings Settings, moves []SnakeMove) (
 }
 
 func (r *SquadRuleset) IsGameOver(b *BoardState) (bool, error) {
-	gameover, _, err := r.Execute(b, r.Settings(), nil)
-	return gameover, err
+	return GameOverSquad(b, r.Settings(), nil)
 }
 
 func GameOverSquad(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {

--- a/squad.go
+++ b/squad.go
@@ -19,20 +19,17 @@ type SquadRuleset struct {
 func (r *SquadRuleset) Name() string { return GameTypeSquad }
 
 func (r SquadRuleset) Pipeline() (*Pipeline, error) {
-	// The squad pipeline extends the standard pipeline
-	standard, err := r.StandardRuleset.Pipeline()
-	if err != nil {
-		return nil, err
-	}
-
-	squad, err := NewPipeline(
+	return NewPipeline(
+		"movement.standard",
+		"reducehealth.standard",
+		"hazarddamage.standard",
+		"eatfood.standard",
+		"placefood.standard",
+		"eliminatesnake.standard",
 		"collision.squad",
 		"sharedattr.squad",
+		"gameover.squad",
 	)
-	if err != nil {
-		return nil, err
-	}
-	return standard.Append(squad), nil
 }
 
 func (r *SquadRuleset) CreateNextBoardState(prevState *BoardState, moves []SnakeMove) (*BoardState, error) {

--- a/squad.go
+++ b/squad.go
@@ -33,13 +33,11 @@ func (r SquadRuleset) Pipeline() (*Pipeline, error) {
 }
 
 func (r *SquadRuleset) CreateNextBoardState(prevState *BoardState, moves []SnakeMove) (*BoardState, error) {
-	nextState := prevState.Clone()
-
 	p, err := r.Pipeline()
 	if err != nil {
 		return nil, err
 	}
-	_, err = p.Execute(nextState, r.Settings(), moves)
+	_, nextState, err := p.Execute(prevState, r.Settings(), moves)
 
 	return nextState, err
 }

--- a/squad.go
+++ b/squad.go
@@ -5,15 +5,15 @@ import (
 )
 
 var squadRulesetStages = []string{
-	"snake.movement.standard",
-	"health.reduce.standard",
-	"hazard.damage.standard",
-	"snake.eatfood.standard",
-	"food.spawn.standard",
-	"snake.eliminate.standard",
-	"snake.collision.squad",
-	"snake.share.squad",
-	"gameover.squad",
+	StageMovementStandard,
+	StageStarvationStandard,
+	StageHazardDamageStandard,
+	StageFeedSnakesStandard,
+	StageSpawnFoodStandard,
+	StageEliminationStandard,
+	StageEliminationResurrectSquadCollisions,
+	StageModifySnakesShareAttributes,
+	StageGameOverBySquad,
 }
 
 type SquadRuleset struct {

--- a/squad.go
+++ b/squad.go
@@ -119,6 +119,9 @@ func (r *SquadRuleset) IsGameOver(b *BoardState) (bool, error) {
 }
 
 func GameOverSquad(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
+	if IsInitialisation(b, settings, moves) {
+		return false, nil
+	}
 	snakesRemaining := []*Snake{}
 	for i := 0; i < len(b.Snakes); i++ {
 		if b.Snakes[i].EliminatedCause == NotEliminated {

--- a/squad.go
+++ b/squad.go
@@ -125,9 +125,6 @@ func (r *SquadRuleset) IsGameOver(b *BoardState) (bool, error) {
 }
 
 func GameOverSquad(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
-	if IsInitialisation(b, settings, moves) {
-		return false, nil
-	}
 	snakesRemaining := []*Snake{}
 	for i := 0; i < len(b.Snakes); i++ {
 		if b.Snakes[i].EliminatedCause == NotEliminated {

--- a/squad_test.go
+++ b/squad_test.go
@@ -26,14 +26,14 @@ func TestSquadCreateNextBoardStateSanity(t *testing.T) {
 func TestSquadResurrectSquadBodyCollisionsSanity(t *testing.T) {
 	boardState := &BoardState{}
 	r := SquadRuleset{}
-	err := r.resurrectSquadBodyCollisions(boardState)
+	_, err := ResurrectSnakesSquad(boardState, r.Settings(), nil)
 	require.NoError(t, err)
 }
 
 func TestSquadSharedAttributesSanity(t *testing.T) {
 	boardState := &BoardState{}
 	r := SquadRuleset{}
-	err := r.shareSquadAttributes(boardState)
+	_, err := ShareAttributesSquad(boardState, r.Settings(), nil)
 	require.NoError(t, err)
 }
 
@@ -77,7 +77,7 @@ func TestSquadAllowBodyCollisions(t *testing.T) {
 	require.Equal(t, len(squadMap), len(boardState.Snakes), "squad map is wrong size, error in test setup")
 
 	r := SquadRuleset{SquadMap: squadMap, AllowBodyCollisions: true}
-	err := r.resurrectSquadBodyCollisions(boardState)
+	_, err := ResurrectSnakesSquad(boardState, r.Settings(), nil)
 
 	require.NoError(t, err)
 	require.Equal(t, len(boardState.Snakes), len(testSnakes))
@@ -113,7 +113,7 @@ func TestSquadAllowBodyCollisionsEliminatedByNotSet(t *testing.T) {
 			"2": "red",
 		},
 	}
-	err := r.resurrectSquadBodyCollisions(boardState)
+	_, err := ResurrectSnakesSquad(boardState, r.Settings(), nil)
 	require.Error(t, err)
 }
 
@@ -152,7 +152,7 @@ func TestSquadShareSquadHealth(t *testing.T) {
 	require.Equal(t, len(squadMap), len(boardState.Snakes), "squad map is wrong size, error in test setup")
 
 	r := SquadRuleset{SharedHealth: true, SquadMap: squadMap}
-	err := r.shareSquadAttributes(boardState)
+	_, err := ShareAttributesSquad(boardState, r.Settings(), nil)
 
 	require.NoError(t, err)
 	require.Equal(t, len(boardState.Snakes), len(testSnakes))
@@ -202,7 +202,7 @@ func TestSquadSharedLength(t *testing.T) {
 	require.Equal(t, len(squadMap), len(boardState.Snakes), "squad map is wrong size, error in test setup")
 
 	r := SquadRuleset{SharedLength: true, SquadMap: squadMap}
-	err := r.shareSquadAttributes(boardState)
+	_, err := ShareAttributesSquad(boardState, r.Settings(), nil)
 
 	require.NoError(t, err)
 	require.Equal(t, len(boardState.Snakes), len(testSnakes))
@@ -255,7 +255,7 @@ func TestSquadSharedElimination(t *testing.T) {
 	require.Equal(t, len(squadMap), len(boardState.Snakes), "squad map is wrong size, error in test setup")
 
 	r := SquadRuleset{SharedElimination: true, SquadMap: squadMap}
-	err := r.shareSquadAttributes(boardState)
+	_, err := ShareAttributesSquad(boardState, r.Settings(), nil)
 
 	require.NoError(t, err)
 	require.Equal(t, len(boardState.Snakes), len(testSnakes))
@@ -291,7 +291,7 @@ func TestSquadSharedAttributesErrorLengthZero(t *testing.T) {
 			"2": "red",
 		},
 	}
-	err := r.shareSquadAttributes(boardState)
+	_, err := ShareAttributesSquad(boardState, r.Settings(), nil)
 	require.Error(t, err)
 }
 

--- a/squad_test.go
+++ b/squad_test.go
@@ -547,8 +547,19 @@ func TestSquadCreateNextBoardState(t *testing.T) {
 		},
 	}
 	rand.Seed(0)
+	rb := NewRulesetBuilder().WithParams(map[string]string{
+		ParamGameType: GameTypeSquad,
+	})
+	rb.WithSeed(0)
+	for s, ss := range r.SquadMap {
+		rb = rb.AddSnakeToSquad(s, ss)
+	}
 	for _, gc := range standardCases {
 		gc.requireValidNextState(t, &r)
+		// also test a RulesBuilder constructed instance
+		gc.requireValidNextState(t, rb.Ruleset())
+		// also test a pipeline with the same settings
+		gc.requireValidNextState(t, rb.PipelineRuleset(GameTypeSquad, NewPipeline(squadRulesetStages...)))
 	}
 
 	extendedCases := []gameTestCase{
@@ -557,7 +568,15 @@ func TestSquadCreateNextBoardState(t *testing.T) {
 	}
 	r.SharedHealth = true
 	r.AllowBodyCollisions = true
+	rb = rb.WithParams(map[string]string{
+		ParamSharedHealth:        "true",
+		ParamAllowBodyCollisions: "true",
+	})
 	for _, gc := range extendedCases {
 		gc.requireValidNextState(t, &r)
+		// also test a RulesBuilder constructed instance
+		gc.requireValidNextState(t, rb.Ruleset())
+		// also test a pipeline with the same settings
+		gc.requireValidNextState(t, rb.PipelineRuleset(GameTypeSquad, NewPipeline(squadRulesetStages...)))
 	}
 }

--- a/squad_test.go
+++ b/squad_test.go
@@ -332,7 +332,6 @@ func TestSquadIsGameOver(t *testing.T) {
 
 	for _, test := range tests {
 		b := &BoardState{
-			Turn:   1, // game can't be over at turn 0, so turn must be at least 1
 			Height: 11,
 			Width:  11,
 			Snakes: test.Snakes,

--- a/squad_test.go
+++ b/squad_test.go
@@ -77,7 +77,7 @@ func TestSquadAllowBodyCollisions(t *testing.T) {
 	require.Equal(t, len(squadMap), len(boardState.Snakes), "squad map is wrong size, error in test setup")
 
 	r := SquadRuleset{SquadMap: squadMap, AllowBodyCollisions: true}
-	_, err := ResurrectSnakesSquad(boardState, r.Settings(), nil)
+	_, err := ResurrectSnakesSquad(boardState, r.Settings(), mockSnakeMoves())
 
 	require.NoError(t, err)
 	require.Equal(t, len(boardState.Snakes), len(testSnakes))
@@ -113,7 +113,7 @@ func TestSquadAllowBodyCollisionsEliminatedByNotSet(t *testing.T) {
 			"2": "red",
 		},
 	}
-	_, err := ResurrectSnakesSquad(boardState, r.Settings(), nil)
+	_, err := ResurrectSnakesSquad(boardState, r.Settings(), mockSnakeMoves())
 	require.Error(t, err)
 }
 
@@ -152,7 +152,7 @@ func TestSquadShareSquadHealth(t *testing.T) {
 	require.Equal(t, len(squadMap), len(boardState.Snakes), "squad map is wrong size, error in test setup")
 
 	r := SquadRuleset{SharedHealth: true, SquadMap: squadMap}
-	_, err := ShareAttributesSquad(boardState, r.Settings(), nil)
+	_, err := ShareAttributesSquad(boardState, r.Settings(), mockSnakeMoves())
 
 	require.NoError(t, err)
 	require.Equal(t, len(boardState.Snakes), len(testSnakes))
@@ -202,7 +202,7 @@ func TestSquadSharedLength(t *testing.T) {
 	require.Equal(t, len(squadMap), len(boardState.Snakes), "squad map is wrong size, error in test setup")
 
 	r := SquadRuleset{SharedLength: true, SquadMap: squadMap}
-	_, err := ShareAttributesSquad(boardState, r.Settings(), nil)
+	_, err := ShareAttributesSquad(boardState, r.Settings(), mockSnakeMoves())
 
 	require.NoError(t, err)
 	require.Equal(t, len(boardState.Snakes), len(testSnakes))
@@ -255,7 +255,7 @@ func TestSquadSharedElimination(t *testing.T) {
 	require.Equal(t, len(squadMap), len(boardState.Snakes), "squad map is wrong size, error in test setup")
 
 	r := SquadRuleset{SharedElimination: true, SquadMap: squadMap}
-	_, err := ShareAttributesSquad(boardState, r.Settings(), nil)
+	_, err := ShareAttributesSquad(boardState, r.Settings(), mockSnakeMoves())
 
 	require.NoError(t, err)
 	require.Equal(t, len(boardState.Snakes), len(testSnakes))
@@ -291,7 +291,7 @@ func TestSquadSharedAttributesErrorLengthZero(t *testing.T) {
 			"2": "red",
 		},
 	}
-	_, err := ShareAttributesSquad(boardState, r.Settings(), nil)
+	_, err := ShareAttributesSquad(boardState, r.Settings(), mockSnakeMoves())
 	require.Error(t, err)
 }
 
@@ -332,6 +332,7 @@ func TestSquadIsGameOver(t *testing.T) {
 
 	for _, test := range tests {
 		b := &BoardState{
+			Turn:   1, // game can't be over at turn 0, so turn must be at least 1
 			Height: 11,
 			Width:  11,
 			Snakes: test.Snakes,

--- a/standard.go
+++ b/standard.go
@@ -402,8 +402,7 @@ func SpawnFoodStandard(b *BoardState, settings Settings, moves []SnakeMove) (boo
 }
 
 func (r *StandardRuleset) IsGameOver(b *BoardState) (bool, error) {
-	gameover, _, err := r.Execute(b, r.Settings(), nil)
-	return gameover, err
+	return GameOverStandard(b, r.Settings(), nil)
 }
 
 func GameOverStandard(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {

--- a/standard.go
+++ b/standard.go
@@ -427,7 +427,7 @@ func (r StandardRuleset) Settings() Settings {
 }
 
 // impl Pipeline
-func (r StandardRuleset) Error() error {
+func (r StandardRuleset) Err() error {
 	return nil
 }
 

--- a/standard.go
+++ b/standard.go
@@ -44,6 +44,11 @@ func MoveSnakesStandard(b *BoardState, settings Settings, moves []SnakeMove) (bo
 		return false, nil
 	}
 
+	// no-op when moves are empty
+	if len(moves) == 0 {
+		return false, nil
+	}
+
 	// Sanity check that all non-eliminated snakes have moves and bodies.
 	for i := 0; i < len(b.Snakes); i++ {
 		snake := &b.Snakes[i]

--- a/standard.go
+++ b/standard.go
@@ -41,7 +41,7 @@ func (r *StandardRuleset) CreateNextBoardState(prevState *BoardState, moves []Sn
 }
 
 func MoveSnakesStandard(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
-	if IsInitialisation(b, settings, moves) {
+	if IsInitialization(b, settings, moves) {
 		return false, nil
 	}
 
@@ -142,7 +142,7 @@ func getDefaultMove(snakeBody []Point) string {
 }
 
 func ReduceSnakeHealthStandard(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
-	if IsInitialisation(b, settings, moves) {
+	if IsInitialization(b, settings, moves) {
 		return false, nil
 	}
 	for i := 0; i < len(b.Snakes); i++ {
@@ -154,7 +154,7 @@ func ReduceSnakeHealthStandard(b *BoardState, settings Settings, moves []SnakeMo
 }
 
 func DamageHazardsStandard(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
-	if IsInitialisation(b, settings, moves) {
+	if IsInitialization(b, settings, moves) {
 		return false, nil
 	}
 	for i := 0; i < len(b.Snakes); i++ {
@@ -192,7 +192,7 @@ func DamageHazardsStandard(b *BoardState, settings Settings, moves []SnakeMove) 
 }
 
 func EliminateSnakesStandard(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
-	if IsInitialisation(b, settings, moves) {
+	if IsInitialization(b, settings, moves) {
 		return false, nil
 	}
 	// First order snake indices by length.
@@ -388,7 +388,7 @@ func growSnake(snake *Snake) {
 }
 
 func SpawnFoodStandard(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
-	if IsInitialisation(b, settings, moves) {
+	if IsInitialization(b, settings, moves) {
 		return false, nil
 	}
 	numCurrentFood := int32(len(b.Food))
@@ -431,8 +431,8 @@ func (r StandardRuleset) Error() error {
 	return nil
 }
 
-// IsInitialisation checks whether the current state means the game is initialising.
-func IsInitialisation(b *BoardState, settings Settings, moves []SnakeMove) bool {
+// IsInitialization checks whether the current state means the game is initialising.
+func IsInitialization(b *BoardState, settings Settings, moves []SnakeMove) bool {
 	// We can safely assume that the game state is in the initialisation phase when
 	// the turn hasn't advanced and the moves are empty
 	return b.Turn <= 0 && len(moves) == 0

--- a/standard.go
+++ b/standard.go
@@ -28,6 +28,7 @@ func (r StandardRuleset) Pipeline() (*Pipeline, error) {
 		"eatfood.standard",
 		"placefood.standard",
 		"eliminatesnake.standard",
+		"gameover.standard",
 	)
 }
 
@@ -42,11 +43,6 @@ func (r *StandardRuleset) CreateNextBoardState(prevState *BoardState, moves []Sn
 	_, err = p.Execute(nextState, r.Settings(), moves)
 
 	return nextState, err
-}
-
-func (r *StandardRuleset) moveSnakes(b *BoardState, moves []SnakeMove) error {
-	_, err := r.callStageFunc(MoveSnakesStandard, b, moves)
-	return err
 }
 
 func MoveSnakesStandard(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
@@ -146,11 +142,6 @@ func getDefaultMove(snakeBody []Point) string {
 	return MoveUp
 }
 
-func (r *StandardRuleset) reduceSnakeHealth(b *BoardState) error {
-	_, err := r.callStageFunc(ReduceSnakeHealthStandard, b, []SnakeMove{})
-	return err
-}
-
 func ReduceSnakeHealthStandard(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
 	for i := 0; i < len(b.Snakes); i++ {
 		if b.Snakes[i].EliminatedCause == NotEliminated {
@@ -158,11 +149,6 @@ func ReduceSnakeHealthStandard(b *BoardState, settings Settings, moves []SnakeMo
 		}
 	}
 	return false, nil
-}
-
-func (r *StandardRuleset) maybeDamageHazards(b *BoardState) error {
-	_, err := r.callStageFunc(DamageHazardsStandard, b, []SnakeMove{})
-	return err
 }
 
 func DamageHazardsStandard(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
@@ -198,11 +184,6 @@ func DamageHazardsStandard(b *BoardState, settings Settings, moves []SnakeMove) 
 	}
 
 	return false, nil
-}
-
-func (r *StandardRuleset) maybeEliminateSnakes(b *BoardState) error {
-	_, err := r.callStageFunc(EliminateSnakesStandard, b, []SnakeMove{})
-	return err
 }
 
 func EliminateSnakesStandard(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
@@ -360,11 +341,6 @@ func snakeHasLostHeadToHead(s *Snake, other *Snake) bool {
 	return false
 }
 
-func (r *StandardRuleset) maybeFeedSnakes(b *BoardState) error {
-	_, err := r.callStageFunc(FeedSnakesStandard, b, []SnakeMove{})
-	return err
-}
-
 func FeedSnakesStandard(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
 	newFood := []Point{}
 	for _, food := range b.Food {
@@ -401,11 +377,6 @@ func growSnake(snake *Snake) {
 	if len(snake.Body) > 0 {
 		snake.Body = append(snake.Body, snake.Body[len(snake.Body)-1])
 	}
-}
-
-func (r *StandardRuleset) maybeSpawnFood(b *BoardState) error {
-	_, err := r.callStageFunc(SpawnFoodStandard, b, []SnakeMove{})
-	return err
 }
 
 func SpawnFoodStandard(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {

--- a/standard.go
+++ b/standard.go
@@ -403,9 +403,6 @@ func (r *StandardRuleset) IsGameOver(b *BoardState) (bool, error) {
 }
 
 func GameOverStandard(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
-	if IsInitialisation(b, settings, moves) {
-		return false, nil
-	}
 	numSnakesRemaining := 0
 	for i := 0; i < len(b.Snakes); i++ {
 		if b.Snakes[i].EliminatedCause == NotEliminated {

--- a/standard.go
+++ b/standard.go
@@ -14,13 +14,13 @@ type StandardRuleset struct {
 }
 
 var standardRulesetStages = []string{
-	"snake.movement.standard",
-	"health.reduce.standard",
-	"hazard.damage.standard",
-	"snake.eatfood.standard",
-	"food.spawn.standard",
-	"snake.eliminate.standard",
-	"gameover.standard",
+	StageMovementStandard,
+	StageStarvationStandard,
+	StageHazardDamageStandard,
+	StageFeedSnakesStandard,
+	StageSpawnFoodStandard,
+	StageEliminationStandard,
+	StageGameOverStandard,
 }
 
 func (r *StandardRuleset) Name() string { return GameTypeStandard }

--- a/standard.go
+++ b/standard.go
@@ -30,6 +30,7 @@ func (r *StandardRuleset) ModifyInitialBoardState(initialState *BoardState) (*Bo
 	return initialState, nil
 }
 
+// impl Pipeline
 func (r StandardRuleset) Execute(bs *BoardState, s Settings, sm []SnakeMove) (bool, *BoardState, error) {
 	return NewPipeline(standardRulesetStages...).Execute(bs, s, sm)
 }
@@ -423,6 +424,11 @@ func (r StandardRuleset) Settings() Settings {
 		HazardMap:           r.HazardMap,
 		HazardMapAuthor:     r.HazardMapAuthor,
 	}
+}
+
+// impl Pipeline
+func (r StandardRuleset) Error() error {
+	return nil
 }
 
 // IsInitialisation checks whether the current state means the game is initialising.

--- a/standard.go
+++ b/standard.go
@@ -22,12 +22,12 @@ func (r *StandardRuleset) ModifyInitialBoardState(initialState *BoardState) (*Bo
 
 func (r StandardRuleset) Pipeline() (*Pipeline, error) {
 	return NewPipeline(
-		"movement.standard",
-		"reducehealth.standard",
-		"hazarddamage.standard",
-		"eatfood.standard",
-		"placefood.standard",
-		"eliminatesnake.standard",
+		"snake.movement.standard",
+		"health.reduce.standard",
+		"hazard.damage.standard",
+		"snake.eatfood.standard",
+		"food.spawn.standard",
+		"snake.eliminate.standard",
 		"gameover.standard",
 	)
 }

--- a/standard.go
+++ b/standard.go
@@ -33,14 +33,11 @@ func (r StandardRuleset) Pipeline() (*Pipeline, error) {
 }
 
 func (r *StandardRuleset) CreateNextBoardState(prevState *BoardState, moves []SnakeMove) (*BoardState, error) {
-	// We specifically want to copy prevState, so as not to alter it directly.
-	nextState := prevState.Clone()
-
 	p, err := r.Pipeline()
 	if err != nil {
 		return nil, err
 	}
-	_, err = p.Execute(nextState, r.Settings(), moves)
+	_, nextState, err := p.Execute(prevState, r.Settings(), moves)
 
 	return nextState, err
 }

--- a/standard.go
+++ b/standard.go
@@ -415,3 +415,21 @@ func (r StandardRuleset) Settings() Settings {
 func (r *StandardRuleset) callStageFunc(stage StageFunc, boardState *BoardState, moves []SnakeMove) (bool, error) {
 	return stage(boardState, r.Settings(), moves)
 }
+
+// IsInitialisation checks whether the current state means the game is initialising.
+func IsInitialisation(b *BoardState, settings Settings, moves []SnakeMove) bool {
+	// We can safely assume that the game state is in the initialisation phase when
+	// the turn hasn't advanced and the moves are empty
+	return b.Turn <= 0 && len(moves) == 0
+}
+
+// WithNoOpOnInit wraps a stage with no-op behavior when a game is in the initialisation stage.
+func WithNoOpOnInit(fn StageFunc) StageFunc {
+	return func(b *BoardState, s Settings, m []SnakeMove) (bool, error) {
+		// If the game is initialising, the stage is a no-op
+		if IsInitialisation(b, s, m) {
+			return false, nil
+		}
+		return fn(b, s, m)
+	}
+}

--- a/standard_test.go
+++ b/standard_test.go
@@ -1610,7 +1610,6 @@ func TestIsGameOver(t *testing.T) {
 	r := StandardRuleset{}
 	for _, test := range tests {
 		b := &BoardState{
-			Turn:   1, // game can't end at turn 0, must be > 0
 			Height: 11,
 			Width:  11,
 			Snakes: test.Snakes,

--- a/standard_test.go
+++ b/standard_test.go
@@ -552,7 +552,7 @@ func TestMoveSnakes(t *testing.T) {
 			{ID: "two", Move: test.MoveTwo},
 			{ID: "three", Move: test.MoveThree},
 		}
-		err := r.moveSnakes(b, moves)
+		_, err := MoveSnakesStandard(b, r.Settings(), moves)
 
 		require.NoError(t, err)
 		require.Len(t, b.Snakes, 3)
@@ -597,7 +597,7 @@ func TestMoveSnakesWrongID(t *testing.T) {
 	}
 
 	r := StandardRuleset{}
-	err := r.moveSnakes(b, moves)
+	_, err := MoveSnakesStandard(b, r.Settings(), moves)
 	require.Equal(t, ErrorNoMoveFound, err)
 }
 
@@ -622,7 +622,7 @@ func TestMoveSnakesNotEnoughMoves(t *testing.T) {
 	}
 
 	r := StandardRuleset{}
-	err := r.moveSnakes(b, moves)
+	_, err := MoveSnakesStandard(b, r.Settings(), moves)
 	require.Equal(t, ErrorNoMoveFound, err)
 }
 
@@ -647,7 +647,7 @@ func TestMoveSnakesExtraMovesIgnored(t *testing.T) {
 	}
 
 	r := StandardRuleset{}
-	err := r.moveSnakes(b, moves)
+	_, err := MoveSnakesStandard(b, r.Settings(), moves)
 	require.NoError(t, err)
 	require.Equal(t, []Point{{1, 0}}, b.Snakes[0].Body)
 }
@@ -699,7 +699,7 @@ func TestMoveSnakesDefault(t *testing.T) {
 		}
 		moves := []SnakeMove{{ID: "one", Move: test.Move}}
 
-		err := r.moveSnakes(b, moves)
+		_, err := MoveSnakesStandard(b, r.Settings(), moves)
 		require.NoError(t, err)
 		require.Len(t, b.Snakes, 1)
 		require.Equal(t, len(test.Body), len(b.Snakes[0].Body))
@@ -795,25 +795,25 @@ func TestReduceSnakeHealth(t *testing.T) {
 	}
 
 	r := StandardRuleset{}
-	err := r.reduceSnakeHealth(b)
+	_, err := ReduceSnakeHealthStandard(b, r.Settings(), nil)
 	require.NoError(t, err)
 	require.Equal(t, b.Snakes[0].Health, int32(98))
 	require.Equal(t, b.Snakes[1].Health, int32(1))
 	require.Equal(t, b.Snakes[2].Health, int32(50))
 
-	err = r.reduceSnakeHealth(b)
+	_, err = ReduceSnakeHealthStandard(b, r.Settings(), nil)
 	require.NoError(t, err)
 	require.Equal(t, b.Snakes[0].Health, int32(97))
 	require.Equal(t, b.Snakes[1].Health, int32(0))
 	require.Equal(t, b.Snakes[2].Health, int32(50))
 
-	err = r.reduceSnakeHealth(b)
+	_, err = ReduceSnakeHealthStandard(b, r.Settings(), nil)
 	require.NoError(t, err)
 	require.Equal(t, b.Snakes[0].Health, int32(96))
 	require.Equal(t, b.Snakes[1].Health, int32(-1))
 	require.Equal(t, b.Snakes[2].Health, int32(50))
 
-	err = r.reduceSnakeHealth(b)
+	_, err = ReduceSnakeHealthStandard(b, r.Settings(), nil)
 	require.NoError(t, err)
 	require.Equal(t, b.Snakes[0].Health, int32(95))
 	require.Equal(t, b.Snakes[1].Health, int32(-2))
@@ -1214,7 +1214,7 @@ func TestMaybeEliminateSnakes(t *testing.T) {
 				Height: 10,
 				Snakes: test.Snakes,
 			}
-			err := r.maybeEliminateSnakes(b)
+			_, err := EliminateSnakesStandard(b, r.Settings(), nil)
 			require.Equal(t, test.Err, err)
 			for i, snake := range b.Snakes {
 				require.Equal(t, test.ExpectedEliminatedCauses[i], snake.EliminatedCause)
@@ -1254,7 +1254,7 @@ func TestMaybeEliminateSnakesPriority(t *testing.T) {
 	r := StandardRuleset{}
 	for _, test := range tests {
 		b := &BoardState{Width: 10, Height: 10, Snakes: test.Snakes}
-		err := r.maybeEliminateSnakes(b)
+		_, err := EliminateSnakesStandard(b, r.Settings(), nil)
 		require.NoError(t, err)
 		for i, snake := range b.Snakes {
 			require.Equal(t, test.ExpectedEliminatedCauses[i], snake.EliminatedCause, snake.ID)
@@ -1320,7 +1320,7 @@ func TestMaybeDamageHazards(t *testing.T) {
 	for _, test := range tests {
 		b := &BoardState{Snakes: test.Snakes, Hazards: test.Hazards, Food: test.Food}
 		r := StandardRuleset{HazardDamagePerTurn: 100}
-		err := r.maybeDamageHazards(b)
+		_, err := DamageHazardsStandard(b, r.Settings(), nil)
 		require.NoError(t, err)
 
 		for i, snake := range b.Snakes {
@@ -1361,7 +1361,7 @@ func TestHazardDamagePerTurn(t *testing.T) {
 		}
 		r := StandardRuleset{HazardDamagePerTurn: test.HazardDamagePerTurn}
 
-		err := r.maybeDamageHazards(b)
+		_, err := DamageHazardsStandard(b, r.Settings(), nil)
 		require.Equal(t, test.Error, err)
 		require.Equal(t, test.ExpectedHealth, b.Snakes[0].Health)
 		require.Equal(t, test.ExpectedEliminationCause, b.Snakes[0].EliminatedCause)
@@ -1441,7 +1441,7 @@ func TestMaybeFeedSnakes(t *testing.T) {
 			Snakes: test.Snakes,
 			Food:   test.Food,
 		}
-		err := r.maybeFeedSnakes(b)
+		_, err := FeedSnakesStandard(b, r.Settings(), nil)
 		require.NoError(t, err, test.Name)
 		require.Equal(t, len(test.ExpectedSnakes), len(b.Snakes), test.Name)
 		for i := 0; i < len(b.Snakes); i++ {
@@ -1477,7 +1477,7 @@ func TestMaybeSpawnFoodMinimum(t *testing.T) {
 			Food: test.Food,
 		}
 
-		err := r.maybeSpawnFood(b)
+		_, err := SpawnFoodStandard(b, r.Settings(), nil)
 		require.NoError(t, err)
 		require.Equal(t, test.ExpectedFood, len(b.Food))
 	}
@@ -1495,7 +1495,7 @@ func TestMaybeSpawnFoodZeroChance(t *testing.T) {
 		Food: []Point{},
 	}
 	for i := 0; i < 1000; i++ {
-		err := r.maybeSpawnFood(b)
+		_, err := SpawnFoodStandard(b, r.Settings(), nil)
 		require.NoError(t, err)
 		require.Equal(t, len(b.Food), 0)
 	}
@@ -1513,7 +1513,7 @@ func TestMaybeSpawnFoodHundredChance(t *testing.T) {
 		Food: []Point{},
 	}
 	for i := 1; i <= 22; i++ {
-		err := r.maybeSpawnFood(b)
+		_, err := SpawnFoodStandard(b, r.Settings(), nil)
 		require.NoError(t, err)
 		require.Equal(t, i, len(b.Food))
 	}
@@ -1547,7 +1547,7 @@ func TestMaybeSpawnFoodHalfChance(t *testing.T) {
 		}
 
 		rand.Seed(test.Seed)
-		err := r.maybeSpawnFood(b)
+		_, err := SpawnFoodStandard(b, r.Settings(), nil)
 		require.NoError(t, err)
 		require.Equal(t, test.ExpectedFood, int32(len(b.Food)), "Seed %d", test.Seed)
 	}

--- a/standard_test.go
+++ b/standard_test.go
@@ -795,25 +795,25 @@ func TestReduceSnakeHealth(t *testing.T) {
 	}
 
 	r := StandardRuleset{}
-	_, err := ReduceSnakeHealthStandard(b, r.Settings(), nil)
+	_, err := ReduceSnakeHealthStandard(b, r.Settings(), mockSnakeMoves())
 	require.NoError(t, err)
 	require.Equal(t, b.Snakes[0].Health, int32(98))
 	require.Equal(t, b.Snakes[1].Health, int32(1))
 	require.Equal(t, b.Snakes[2].Health, int32(50))
 
-	_, err = ReduceSnakeHealthStandard(b, r.Settings(), nil)
+	_, err = ReduceSnakeHealthStandard(b, r.Settings(), mockSnakeMoves())
 	require.NoError(t, err)
 	require.Equal(t, b.Snakes[0].Health, int32(97))
 	require.Equal(t, b.Snakes[1].Health, int32(0))
 	require.Equal(t, b.Snakes[2].Health, int32(50))
 
-	_, err = ReduceSnakeHealthStandard(b, r.Settings(), nil)
+	_, err = ReduceSnakeHealthStandard(b, r.Settings(), mockSnakeMoves())
 	require.NoError(t, err)
 	require.Equal(t, b.Snakes[0].Health, int32(96))
 	require.Equal(t, b.Snakes[1].Health, int32(-1))
 	require.Equal(t, b.Snakes[2].Health, int32(50))
 
-	_, err = ReduceSnakeHealthStandard(b, r.Settings(), nil)
+	_, err = ReduceSnakeHealthStandard(b, r.Settings(), mockSnakeMoves())
 	require.NoError(t, err)
 	require.Equal(t, b.Snakes[0].Health, int32(95))
 	require.Equal(t, b.Snakes[1].Health, int32(-2))
@@ -1214,7 +1214,7 @@ func TestMaybeEliminateSnakes(t *testing.T) {
 				Height: 10,
 				Snakes: test.Snakes,
 			}
-			_, err := EliminateSnakesStandard(b, r.Settings(), nil)
+			_, err := EliminateSnakesStandard(b, r.Settings(), mockSnakeMoves())
 			require.Equal(t, test.Err, err)
 			for i, snake := range b.Snakes {
 				require.Equal(t, test.ExpectedEliminatedCauses[i], snake.EliminatedCause)
@@ -1254,7 +1254,7 @@ func TestMaybeEliminateSnakesPriority(t *testing.T) {
 	r := StandardRuleset{}
 	for _, test := range tests {
 		b := &BoardState{Width: 10, Height: 10, Snakes: test.Snakes}
-		_, err := EliminateSnakesStandard(b, r.Settings(), nil)
+		_, err := EliminateSnakesStandard(b, r.Settings(), mockSnakeMoves())
 		require.NoError(t, err)
 		for i, snake := range b.Snakes {
 			require.Equal(t, test.ExpectedEliminatedCauses[i], snake.EliminatedCause, snake.ID)
@@ -1320,7 +1320,7 @@ func TestMaybeDamageHazards(t *testing.T) {
 	for _, test := range tests {
 		b := &BoardState{Snakes: test.Snakes, Hazards: test.Hazards, Food: test.Food}
 		r := StandardRuleset{HazardDamagePerTurn: 100}
-		_, err := DamageHazardsStandard(b, r.Settings(), nil)
+		_, err := DamageHazardsStandard(b, r.Settings(), mockSnakeMoves())
 		require.NoError(t, err)
 
 		for i, snake := range b.Snakes {
@@ -1361,7 +1361,7 @@ func TestHazardDamagePerTurn(t *testing.T) {
 		}
 		r := StandardRuleset{HazardDamagePerTurn: test.HazardDamagePerTurn}
 
-		_, err := DamageHazardsStandard(b, r.Settings(), nil)
+		_, err := DamageHazardsStandard(b, r.Settings(), mockSnakeMoves())
 		require.Equal(t, test.Error, err)
 		require.Equal(t, test.ExpectedHealth, b.Snakes[0].Health)
 		require.Equal(t, test.ExpectedEliminationCause, b.Snakes[0].EliminatedCause)
@@ -1477,7 +1477,7 @@ func TestMaybeSpawnFoodMinimum(t *testing.T) {
 			Food: test.Food,
 		}
 
-		_, err := SpawnFoodStandard(b, r.Settings(), nil)
+		_, err := SpawnFoodStandard(b, r.Settings(), mockSnakeMoves())
 		require.NoError(t, err)
 		require.Equal(t, test.ExpectedFood, len(b.Food))
 	}
@@ -1513,7 +1513,7 @@ func TestMaybeSpawnFoodHundredChance(t *testing.T) {
 		Food: []Point{},
 	}
 	for i := 1; i <= 22; i++ {
-		_, err := SpawnFoodStandard(b, r.Settings(), nil)
+		_, err := SpawnFoodStandard(b, r.Settings(), mockSnakeMoves())
 		require.NoError(t, err)
 		require.Equal(t, i, len(b.Food))
 	}
@@ -1547,7 +1547,7 @@ func TestMaybeSpawnFoodHalfChance(t *testing.T) {
 		}
 
 		rand.Seed(test.Seed)
-		_, err := SpawnFoodStandard(b, r.Settings(), nil)
+		_, err := SpawnFoodStandard(b, r.Settings(), mockSnakeMoves())
 		require.NoError(t, err)
 		require.Equal(t, test.ExpectedFood, int32(len(b.Food)), "Seed %d", test.Seed)
 	}
@@ -1610,6 +1610,7 @@ func TestIsGameOver(t *testing.T) {
 	r := StandardRuleset{}
 	for _, test := range tests {
 		b := &BoardState{
+			Turn:   1, // game can't end at turn 0, must be > 0
 			Height: 11,
 			Width:  11,
 			Snakes: test.Snakes,

--- a/standard_test.go
+++ b/standard_test.go
@@ -218,8 +218,15 @@ func TestStandardCreateNextBoardState(t *testing.T) {
 		standardMoveAndCollideMAD,
 	}
 	r := StandardRuleset{}
+	rb := NewRulesetBuilder().WithParams(map[string]string{
+		ParamGameType: GameTypeStandard,
+	})
 	for _, gc := range cases {
 		gc.requireValidNextState(t, &r)
+		// also test a RulesBuilder constructed instance
+		gc.requireValidNextState(t, rb.Ruleset())
+		// also test a pipeline with the same settings
+		gc.requireValidNextState(t, NewRulesetBuilder().PipelineRuleset(GameTypeStandard, NewPipeline(standardRulesetStages...)))
 	}
 }
 

--- a/wrapped.go
+++ b/wrapped.go
@@ -18,13 +18,11 @@ func (r WrappedRuleset) Pipeline() (*Pipeline, error) {
 }
 
 func (r *WrappedRuleset) CreateNextBoardState(prevState *BoardState, moves []SnakeMove) (*BoardState, error) {
-	nextState := prevState.Clone()
-
 	p, err := r.Pipeline()
 	if err != nil {
 		return nil, err
 	}
-	_, err = p.Execute(nextState, r.Settings(), moves)
+	_, nextState, err := p.Execute(prevState, r.Settings(), moves)
 
 	return nextState, err
 }

--- a/wrapped.go
+++ b/wrapped.go
@@ -26,7 +26,7 @@ func (r *WrappedRuleset) CreateNextBoardState(prevState *BoardState, moves []Sna
 }
 
 func MoveSnakesWrapped(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
-	if IsInitialisation(b, settings, moves) {
+	if IsInitialization(b, settings, moves) {
 		return false, nil
 	}
 

--- a/wrapped.go
+++ b/wrapped.go
@@ -8,12 +8,12 @@ func (r *WrappedRuleset) Name() string { return GameTypeWrapped }
 
 func (r WrappedRuleset) Pipeline() (*Pipeline, error) {
 	return NewPipeline(
-		"movement.wrapped",
-		"reducehealth.standard",
-		"hazarddamage.standard",
-		"eatfood.standard",
-		"placefood.standard",
-		"eliminatesnake.standard",
+		"snake.movement.wrapped",
+		"health.reduce.standard",
+		"hazard.damage.standard",
+		"snake.eatfood.standard",
+		"food.spawn.standard",
+		"snake.eliminate.standard",
 	)
 }
 

--- a/wrapped.go
+++ b/wrapped.go
@@ -29,11 +29,6 @@ func (r *WrappedRuleset) CreateNextBoardState(prevState *BoardState, moves []Sna
 	return nextState, err
 }
 
-func (r *WrappedRuleset) moveSnakes(b *BoardState, moves []SnakeMove) error {
-	_, err := r.callStageFunc(MoveSnakesWrapped, b, moves)
-	return err
-}
-
 func MoveSnakesWrapped(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
 	_, err := MoveSnakesStandard(b, settings, moves)
 	if err != nil {

--- a/wrapped.go
+++ b/wrapped.go
@@ -6,40 +6,27 @@ type WrappedRuleset struct {
 
 func (r *WrappedRuleset) Name() string { return GameTypeWrapped }
 
+func (r WrappedRuleset) Pipeline() (*Pipeline, error) {
+	return NewPipeline(
+		"movement.wrapped",
+		"reducehealth.standard",
+		"hazarddamage.standard",
+		"eatfood.standard",
+		"placefood.standard",
+		"eliminatesnake.standard",
+	)
+}
+
 func (r *WrappedRuleset) CreateNextBoardState(prevState *BoardState, moves []SnakeMove) (*BoardState, error) {
 	nextState := prevState.Clone()
 
-	err := r.moveSnakes(nextState, moves)
+	p, err := r.Pipeline()
 	if err != nil {
 		return nil, err
 	}
+	_, err = p.Execute(nextState, r.Settings(), moves)
 
-	err = r.reduceSnakeHealth(nextState)
-	if err != nil {
-		return nil, err
-	}
-
-	err = r.maybeDamageHazards(nextState)
-	if err != nil {
-		return nil, err
-	}
-
-	err = r.maybeFeedSnakes(nextState)
-	if err != nil {
-		return nil, err
-	}
-
-	err = r.maybeSpawnFood(nextState)
-	if err != nil {
-		return nil, err
-	}
-
-	err = r.maybeEliminateSnakes(nextState)
-	if err != nil {
-		return nil, err
-	}
-
-	return nextState, nil
+	return nextState, err
 }
 
 func (r *WrappedRuleset) moveSnakes(b *BoardState, moves []SnakeMove) error {

--- a/wrapped.go
+++ b/wrapped.go
@@ -7,6 +7,7 @@ var wrappedRulesetStages = []string{
 	StageFeedSnakesStandard,
 	StageSpawnFoodStandard,
 	StageEliminationStandard,
+	StageGameOverStandard,
 }
 
 type WrappedRuleset struct {
@@ -45,6 +46,11 @@ func MoveSnakesWrapped(b *BoardState, settings Settings, moves []SnakeMove) (boo
 	}
 
 	return false, nil
+}
+
+func (r *WrappedRuleset) IsGameOver(b *BoardState) (bool, error) {
+	gameover, _, err := r.Execute(b, r.Settings(), nil)
+	return gameover, err
 }
 
 func wrap(value, min, max int32) int32 {

--- a/wrapped.go
+++ b/wrapped.go
@@ -49,8 +49,7 @@ func MoveSnakesWrapped(b *BoardState, settings Settings, moves []SnakeMove) (boo
 }
 
 func (r *WrappedRuleset) IsGameOver(b *BoardState) (bool, error) {
-	gameover, _, err := r.Execute(b, r.Settings(), nil)
-	return gameover, err
+	return GameOverStandard(b, r.Settings(), nil)
 }
 
 func wrap(value, min, max int32) int32 {

--- a/wrapped.go
+++ b/wrapped.go
@@ -1,12 +1,12 @@
 package rules
 
 var wrappedRulesetStages = []string{
-	"snake.movement.wrapped",
-	"health.reduce.standard",
-	"hazard.damage.standard",
-	"snake.eatfood.standard",
-	"food.spawn.standard",
-	"snake.eliminate.standard",
+	StageMovementWrapBoundaries,
+	StageStarvationStandard,
+	StageHazardDamageStandard,
+	StageFeedSnakesStandard,
+	StageSpawnFoodStandard,
+	StageEliminationStandard,
 }
 
 type WrappedRuleset struct {

--- a/wrapped.go
+++ b/wrapped.go
@@ -28,6 +28,10 @@ func (r *WrappedRuleset) CreateNextBoardState(prevState *BoardState, moves []Sna
 }
 
 func MoveSnakesWrapped(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
+	if IsInitialisation(b, settings, moves) {
+		return false, nil
+	}
+
 	_, err := MoveSnakesStandard(b, settings, moves)
 	if err != nil {
 		return false, err

--- a/wrapped.go
+++ b/wrapped.go
@@ -1,28 +1,26 @@
 package rules
 
+var wrappedRulesetStages = []string{
+	"snake.movement.wrapped",
+	"health.reduce.standard",
+	"hazard.damage.standard",
+	"snake.eatfood.standard",
+	"food.spawn.standard",
+	"snake.eliminate.standard",
+}
+
 type WrappedRuleset struct {
 	StandardRuleset
 }
 
 func (r *WrappedRuleset) Name() string { return GameTypeWrapped }
 
-func (r WrappedRuleset) Pipeline() (*Pipeline, error) {
-	return NewPipeline(
-		"snake.movement.wrapped",
-		"health.reduce.standard",
-		"hazard.damage.standard",
-		"snake.eatfood.standard",
-		"food.spawn.standard",
-		"snake.eliminate.standard",
-	)
+func (r WrappedRuleset) Execute(bs *BoardState, s Settings, sm []SnakeMove) (bool, *BoardState, error) {
+	return NewPipeline(wrappedRulesetStages...).Execute(bs, s, sm)
 }
 
 func (r *WrappedRuleset) CreateNextBoardState(prevState *BoardState, moves []SnakeMove) (*BoardState, error) {
-	p, err := r.Pipeline()
-	if err != nil {
-		return nil, err
-	}
-	_, nextState, err := p.Execute(prevState, r.Settings(), moves)
+	_, nextState, err := r.Execute(prevState, r.Settings(), moves)
 
 	return nextState, err
 }

--- a/wrapped_test.go
+++ b/wrapped_test.go
@@ -331,7 +331,14 @@ func TestWrappedCreateNextBoardState(t *testing.T) {
 		wrappedCaseMoveAndWrap,
 	}
 	r := WrappedRuleset{}
+	rb := NewRulesetBuilder().WithParams(map[string]string{
+		ParamGameType: GameTypeWrapped,
+	})
 	for _, gc := range cases {
 		gc.requireValidNextState(t, &r)
+		// also test a RulesBuilder constructed instance
+		gc.requireValidNextState(t, rb.Ruleset())
+		// also test a pipeline with the same settings
+		gc.requireValidNextState(t, NewRulesetBuilder().PipelineRuleset(GameTypeWrapped, NewPipeline(wrappedRulesetStages...)))
 	}
 }


### PR DESCRIPTION
This PR adds a new concept called "pipelines" to the rules package. It is intended as a replacement for the "ruleset" concept. While Rulesets are still supported, the internal implementation of them has been re-written to be entirely Pipeline based, so there is no significant reason to continue using them in new code.

A "pipeline" is a series of "stage functions" which are executed in sequence, one after another, in order to modify a game state and produce a next game state. Pipelines can also be executed to initialise a game state and to check if a game has ended. The design of the pipeline system is intended to facilitate easy customization and extension of game modes. Each existing game mode has been broken down into a series of bite-sized logic, called "stages", so that the stages can be re-used in other game modes. For example, the logic to move snakes each turn is its own stage. Any other game type that wishes to have this type of movement behavior can simply include this stage.

Overview:
- added new Pipeline type which is a series of stages
- added a global registry of pipeline stages
- re-wrote Ruleset internals to use Pipeline
- full test coverage of new types/methods