### PR TITLE
DEV 1253: Upgrade to Go 1.18.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+env:
+  GO_VERSION: 1.18.1
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -18,7 +21,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: '${{ env.GO_VERSION }}'
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on: [push, pull_request]
 
+env:
+  GO_VERSION: 1.18.1
+
 jobs:
 
   format:
@@ -11,7 +14,7 @@ jobs:
     - uses: actions/checkout@main
     - uses: actions/setup-go@main
       with:
-        go-version: '1.17'
+        go-version: '${{ env.GO_VERSION }}'
     - name: Run gofmt
       run: test -z $(gofmt -l .) || (gofmt -d . && exit 1)
 
@@ -23,7 +26,7 @@ jobs:
       - uses: actions/checkout@main
       - uses: actions/setup-go@main
         with:
-          go-version: '1.17'
+          go-version: '${{ env.GO_VERSION }}'
       - name: Run golangci-lint
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0
@@ -37,7 +40,7 @@ jobs:
     - uses: actions/checkout@main
     - uses: actions/setup-go@main
       with:
-        go-version: '1.17'
+        go-version: '${{ env.GO_VERSION }}'
     - name: Run go test
       run: go test -race -coverprofile=coverage.txt ./...
     - name: Upload coverage to codecov.io
@@ -56,7 +59,7 @@ jobs:
     - uses: actions/checkout@main
     - uses: actions/setup-go@main
       with:
-        go-version: '1.17'
+        go-version: '${{ env.GO_VERSION }}'
     - name: Run go build
       run: |
         go build ./cli/battlesnake

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           go-version: '${{ env.GO_VERSION }}'
       - name: Run golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2
           golangci-lint run -v ./...
 
   test:

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ This repo provides a simple CLI tool to run games locally against your dev envir
 Download precompiled binaries here: <br>
 [https://github.com/BattlesnakeOfficial/rules/releases](https://github.com/BattlesnakeOfficial/rules/releases)
 
-Install as a Go package. Requires Go 1.17 or higher. [[Download](https://golang.org/dl/)]
+Install as a Go package. Requires Go 1.18 or higher. [[Download](https://golang.org/dl/)]
 ```
 go get github.com/BattlesnakeOfficial/rules/cli/battlesnake
 ```
 
-Compile from source. Also requires Go 1.17 or higher.
+Compile from source. Also requires Go 1.18 or higher.
 ```
 git clone git@github.com:BattlesnakeOfficial/rules.git
 cd rules

--- a/cli/README.md
+++ b/cli/README.md
@@ -7,12 +7,12 @@ This tool allows running a Battlesnake game locally. There are several command-l
 Download precompiled binaries here: <br>
 [https://github.com/BattlesnakeOfficial/rules/releases](https://github.com/BattlesnakeOfficial/rules/releases)
 
-Install as a Go package. Requires Go 1.17 or higher. [[Download](https://golang.org/dl/)]
+Install as a Go package. Requires Go 1.18 or higher. [[Download](https://golang.org/dl/)]
 ```
 go get github.com/BattlesnakeOfficial/rules/cli/battlesnake
 ```
 
-Compile from source. Also requires Go 1.17 or higher.
+Compile from source. Also requires Go 1.18 or higher.
 ```
 git clone git@github.com:BattlesnakeOfficial/rules.git
 cd rules

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
-	golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0 // indirect
+	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 // indirect
 	golang.org/x/text v0.3.2 // indirect
 	gopkg.in/ini.v1 v1.51.0 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/BattlesnakeOfficial/rules
 
-go 1.17
+go 1.18
 
 require (
 	github.com/google/uuid v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -251,6 +251,8 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0 h1:HyfiK1WMnHj5FXFXatD+Qs1A/xC2Run6RzeW1SyHxpc=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
+golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=


### PR DESCRIPTION
This upgrades the Go version to 1.18.1, along with making a few minor dependency upgrades to fix incompatibilities.