### PR TITLE
CLI json output isDraw always false

### DIFF
--- a/cli/commands/play.go
+++ b/cli/commands/play.go
@@ -231,6 +231,7 @@ func (gameState *GameState) Run() {
 		}
 		if exportGame {
 			gameExporter.winner = winner
+			gameExporter.isDraw = isDraw
 		}
 	}
 


### PR DESCRIPTION
## Description
I just started building my first snake ([Snattle](https://github.com/MNThomson/Snattle)!), and in trying to link the `cli` for DQLearning I noticed that `isDraw` is always `false`. The output is hard-coded to `false` in `commands/play.go`: https://github.com/BattlesnakeOfficial/rules/blob/1adbc79168a6037e1025c46bc4a8c754de6f0442/cli/commands/play.go#L155-L160

## Example
CLI output:
```bash
$ battlesnake play --url http://localhost:8080 --url http://localhost:8000 -W 5 -H 5 -o game.json
...
2022/05/29 16:55:37 [DONE]: Game completed after 3 turns. It was a draw.
2022/05/29 16:55:37 Written 5 lines of output to file: game.json
```
### JSON Before
```json
{"winnerId":"","winnerName":"","isDraw":false}
```

### JSON After
```json
{"winnerId":"","winnerName":"","isDraw":true}
```

