### PR TITLE
DEV-1373: Reorder built-in ruleset stages so that game over is checked first

### DIFF
--- a/constrictor.go
+++ b/constrictor.go
@@ -1,6 +1,7 @@
 package rules
 
 var constrictorRulesetStages = []string{
+	StageGameOverStandard,
 	StageMovementStandard,
 	StageStarvationStandard,
 	StageHazardDamageStandard,
@@ -8,7 +9,6 @@ var constrictorRulesetStages = []string{
 	StageEliminationStandard,
 	StageSpawnFoodNoFood,
 	StageModifySnakesAlwaysGrow,
-	StageGameOverStandard,
 }
 
 type ConstrictorRuleset struct {

--- a/constrictor_test.go
+++ b/constrictor_test.go
@@ -2,46 +2,10 @@ package rules
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestConstrictorRulesetInterface(t *testing.T) {
 	var _ Ruleset = (*ConstrictorRuleset)(nil)
-}
-
-func TestConstrictorModifyInitialBoardState(t *testing.T) {
-	tests := []struct {
-		Height int
-		Width  int
-		IDs    []string
-	}{
-		{1, 1, []string{}},
-		{1, 1, []string{"one"}},
-		{2, 2, []string{"one"}},
-		{2, 2, []string{"one", "two"}},
-		{11, 1, []string{"one", "two"}},
-		{11, 11, []string{}},
-		{11, 11, []string{"one", "two", "three", "four", "five"}},
-	}
-	r := ConstrictorRuleset{}
-	for testNum, test := range tests {
-		state, err := CreateDefaultBoardState(MaxRand, test.Width, test.Height, test.IDs)
-		require.NoError(t, err)
-		require.NotNil(t, state)
-		state, err = r.ModifyInitialBoardState(state)
-		require.NoError(t, err)
-		require.NotNil(t, state)
-		require.Equal(t, test.Width, state.Width)
-		require.Equal(t, test.Height, state.Height)
-		require.Len(t, state.Food, 0, testNum)
-		// Verify snakes
-		require.Equal(t, len(test.IDs), len(state.Snakes))
-		for i, id := range test.IDs {
-			require.Equal(t, id, state.Snakes[i].ID)
-			require.Equal(t, state.Snakes[i].Body[2], state.Snakes[i].Body[1])
-		}
-	}
 }
 
 // Test that two equal snakes collide and both get eliminated

--- a/royale.go
+++ b/royale.go
@@ -5,13 +5,13 @@ import (
 )
 
 var royaleRulesetStages = []string{
+	StageGameOverStandard,
 	StageMovementStandard,
 	StageStarvationStandard,
 	StageHazardDamageStandard,
 	StageFeedSnakesStandard,
 	StageEliminationStandard,
 	StageSpawnHazardsShrinkMap,
-	StageGameOverStandard,
 }
 
 type RoyaleRuleset struct {

--- a/royale_test.go
+++ b/royale_test.go
@@ -13,9 +13,14 @@ func TestRoyaleRulesetInterface(t *testing.T) {
 }
 
 func TestRoyaleDefaultSanity(t *testing.T) {
-	boardState := &BoardState{}
+	boardState := &BoardState{
+		Snakes: []Snake{
+			{ID: "1", Body: []Point{{X: 0, Y: 0}}},
+			{ID: "2", Body: []Point{{X: 0, Y: 1}}},
+		},
+	}
 	r := RoyaleRuleset{StandardRuleset: StandardRuleset{HazardDamagePerTurn: 1}, ShrinkEveryNTurns: 0}
-	_, err := r.CreateNextBoardState(boardState, []SnakeMove{{"", ""}})
+	_, err := r.CreateNextBoardState(boardState, []SnakeMove{{"1", "right"}, {"2", "right"}})
 	require.Error(t, err)
 	require.Equal(t, errors.New("royale game can't shrink more frequently than every turn"), err)
 

--- a/solo.go
+++ b/solo.go
@@ -1,12 +1,12 @@
 package rules
 
 var soloRulesetStages = []string{
+	StageGameOverSoloSnake,
 	StageMovementStandard,
 	StageStarvationStandard,
 	StageHazardDamageStandard,
 	StageFeedSnakesStandard,
 	StageEliminationStandard,
-	StageGameOverSoloSnake,
 }
 
 type SoloRuleset struct {
@@ -17,6 +17,11 @@ func (r *SoloRuleset) Name() string { return GameTypeSolo }
 
 func (r SoloRuleset) Execute(bs *BoardState, s Settings, sm []SnakeMove) (bool, *BoardState, error) {
 	return NewPipeline(soloRulesetStages...).Execute(bs, s, sm)
+}
+
+func (r *SoloRuleset) CreateNextBoardState(prevState *BoardState, moves []SnakeMove) (*BoardState, error) {
+	_, nextState, err := r.Execute(prevState, r.Settings(), moves)
+	return nextState, err
 }
 
 func (r *SoloRuleset) IsGameOver(b *BoardState) (bool, error) {

--- a/standard.go
+++ b/standard.go
@@ -14,12 +14,12 @@ type StandardRuleset struct {
 }
 
 var standardRulesetStages = []string{
+	StageGameOverStandard,
 	StageMovementStandard,
 	StageStarvationStandard,
 	StageHazardDamageStandard,
 	StageFeedSnakesStandard,
 	StageEliminationStandard,
-	StageGameOverStandard,
 }
 
 func (r *StandardRuleset) Name() string { return GameTypeStandard }

--- a/wrapped.go
+++ b/wrapped.go
@@ -1,12 +1,12 @@
 package rules
 
 var wrappedRulesetStages = []string{
+	StageGameOverStandard,
 	StageMovementWrapBoundaries,
 	StageStarvationStandard,
 	StageHazardDamageStandard,
 	StageFeedSnakesStandard,
 	StageEliminationStandard,
-	StageGameOverStandard,
 }
 
 type WrappedRuleset struct {


### PR DESCRIPTION
This fixes an edge case where games run through the CLI would sometimes end a turn before the actual end game condition. This looked like the snakes weren't getting their elimination cause set, but the actual issue was that the game was ending early.

Note: the production engine does not use this code path, so games should be unaffected. It only affects the CLI and uses of rules as a library.