### PR TITLE
Add a "Version" field to game maps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 )
 
 require (
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.4.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.4.7 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,6 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
-github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
-github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -249,7 +251,6 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0 h1:HyfiK1WMnHj5FXFXatD+Qs1A/xC2Run6RzeW1SyHxpc=
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/maps/arcade_maze.go
+++ b/maps/arcade_maze.go
@@ -19,6 +19,7 @@ func (m ArcadeMazeMap) Meta() Metadata {
 		Name:        "Arcade Maze",
 		Description: "Generic arcade maze map with hazard walls",
 		Author:      "Battlesnake",
+		Version:     "0.1.0",
 	}
 }
 

--- a/maps/arcade_maze.go
+++ b/maps/arcade_maze.go
@@ -19,7 +19,7 @@ func (m ArcadeMazeMap) Meta() Metadata {
 		Name:        "Arcade Maze",
 		Description: "Generic arcade maze map with hazard walls",
 		Author:      "Battlesnake",
-		Version:     "0.1.0",
+		Version:     1,
 	}
 }
 

--- a/maps/empty.go
+++ b/maps/empty.go
@@ -19,7 +19,7 @@ func (m EmptyMap) Meta() Metadata {
 		Name:        "Empty",
 		Description: "Default snake placement with no food",
 		Author:      "Battlesnake",
-		Version:     "0.1.0",
+		Version:     1,
 	}
 }
 

--- a/maps/empty.go
+++ b/maps/empty.go
@@ -19,6 +19,7 @@ func (m EmptyMap) Meta() Metadata {
 		Name:        "Empty",
 		Description: "Default snake placement with no food",
 		Author:      "Battlesnake",
+		Version:     "0.1.0",
 	}
 }
 

--- a/maps/game_map.go
+++ b/maps/game_map.go
@@ -1,6 +1,9 @@
 package maps
 
-import "github.com/BattlesnakeOfficial/rules"
+import (
+	"github.com/BattlesnakeOfficial/rules"
+	"github.com/blang/semver/v4"
+)
 
 type GameMap interface {
 	// Return a unique identifier for this map.
@@ -16,10 +19,24 @@ type GameMap interface {
 	UpdateBoard(previousBoardState *rules.BoardState, settings rules.Settings, editor Editor) error
 }
 
+// version is an internal type used to represent the version of a game map.
+// A valid  version string conforms to semantic versioning (https://semver.org/).
+// Examples: ["0.0.1", "1.2.34", "0.1.0"].
+type version string
+
+// IsValid returns whether the version is a valid semantic version string
+func (v version) IsValid() bool {
+	_, err := semver.Parse(string(v))
+	return err == nil
+}
+
 type Metadata struct {
 	Name        string
 	Author      string
 	Description string
+	// Version is the current, semver version of the map.
+	// Must be a valid semver (https://semver.org/) string.
+	Version version
 }
 
 // Editor is used by GameMap implementations to modify the board state.

--- a/maps/game_map.go
+++ b/maps/game_map.go
@@ -2,7 +2,6 @@ package maps
 
 import (
 	"github.com/BattlesnakeOfficial/rules"
-	"github.com/blang/semver/v4"
 )
 
 type GameMap interface {
@@ -19,24 +18,13 @@ type GameMap interface {
 	UpdateBoard(previousBoardState *rules.BoardState, settings rules.Settings, editor Editor) error
 }
 
-// version is an internal type used to represent the version of a game map.
-// A valid  version string conforms to semantic versioning (https://semver.org/).
-// Examples: ["0.0.1", "1.2.34", "0.1.0"].
-type version string
-
-// IsValid returns whether the version is a valid semantic version string
-func (v version) IsValid() bool {
-	_, err := semver.Parse(string(v))
-	return err == nil
-}
-
 type Metadata struct {
 	Name        string
 	Author      string
 	Description string
-	// Version is the current, semver version of the map.
-	// Must be a valid semver (https://semver.org/) string.
-	Version version
+	// Version is the current version of the game map.
+	// Each time a map is changed, the version number should be incremented by 1.
+	Version uint
 }
 
 // Editor is used by GameMap implementations to modify the board state.

--- a/maps/hazards.go
+++ b/maps/hazards.go
@@ -29,7 +29,7 @@ func (m InnerBorderHazardsMap) Meta() Metadata {
 		Name:        "hz_inner_wall",
 		Description: "Creates a static map on turn 0 that is a 1-square wall of hazard that is inset 2 squares from the edge of the board",
 		Author:      "Battlesnake",
-		Version:     "0.1.0",
+		Version:     1,
 	}
 }
 
@@ -66,7 +66,7 @@ func (m ConcentricRingsHazardsMap) Meta() Metadata {
 		Name:        "hz_rings",
 		Description: "Creates a static map where there are rings of hazard sauce starting from the center with a 1 square space between the rings that has no sauce",
 		Author:      "Battlesnake",
-		Version:     "0.1.0",
+		Version:     1,
 	}
 }
 
@@ -104,7 +104,7 @@ func (m ColumnsHazardsMap) Meta() Metadata {
 		Name:        "hz_columns",
 		Description: "Creates a static map on turn 0 that fills in odd squares, i.e. (1,1), (1,3), (3,3) ... with hazard sauce",
 		Author:      "Battlesnake",
-		Version:     "0.1.0",
+		Version:     1,
 	}
 }
 
@@ -140,7 +140,7 @@ func (m SpiralHazardsMap) Meta() Metadata {
 		Description: `Generates a dynamic hazard map that grows in a spiral pattern clockwise from a random point on
  the map. Each 2 turns a new hazard square is added to the map`,
 		Author:  "altersaddle",
-		Version: "0.1.0",
+		Version: 1,
 	}
 }
 
@@ -229,7 +229,7 @@ func (m ScatterFillMap) Meta() Metadata {
 	return Metadata{
 		Name:        "hz_scatter",
 		Description: `Fills the entire board with hazard squares that are set to appear on regular turn schedule. Each square is picked at random.`,
-		Version:     "0.1.0",
+		Version:     1,
 	}
 }
 
@@ -277,7 +277,7 @@ func (m DirectionalExpandingBoxMap) Meta() Metadata {
 	return Metadata{
 		Name:        "hz_grow_box",
 		Description: `Creates an area of hazard that expands from a point with one random side growing on a turn schedule.`,
-		Version:     "0.1.0",
+		Version:     1,
 	}
 }
 
@@ -388,7 +388,7 @@ func (m ExpandingBoxMap) Meta() Metadata {
 	return Metadata{
 		Name:        "hz_expand_box",
 		Description: `Generates an area of hazard that expands from a random point on the board outward in concentric rings on a periodic turn schedule.`,
-		Version:     "0.1.0",
+		Version:     1,
 	}
 }
 
@@ -460,7 +460,7 @@ func (m ExpandingScatterMap) Meta() Metadata {
 	return Metadata{
 		Name:        "hz_expand_scatter",
 		Description: `Builds an expanding hazard area that grows from a central point in rings that are randomly filled in on a regular turn schedule.`,
-		Version:     "0.1.0",
+		Version:     1,
 	}
 }
 
@@ -539,7 +539,7 @@ func (m RiverAndBridgesHazardsMap) Meta() Metadata {
 		Description: `Creates fixed maps that have a lake of hazard in the middle with rivers going in the cardinal directions.
 Each river has one or two 1-square "bridges" over them`,
 		Author:  "Battlesnake",
-		Version: "0.1.0",
+		Version: 1,
 	}
 }
 

--- a/maps/hazards.go
+++ b/maps/hazards.go
@@ -29,6 +29,7 @@ func (m InnerBorderHazardsMap) Meta() Metadata {
 		Name:        "hz_inner_wall",
 		Description: "Creates a static map on turn 0 that is a 1-square wall of hazard that is inset 2 squares from the edge of the board",
 		Author:      "Battlesnake",
+		Version:     "0.1.0",
 	}
 }
 
@@ -65,6 +66,7 @@ func (m ConcentricRingsHazardsMap) Meta() Metadata {
 		Name:        "hz_rings",
 		Description: "Creates a static map where there are rings of hazard sauce starting from the center with a 1 square space between the rings that has no sauce",
 		Author:      "Battlesnake",
+		Version:     "0.1.0",
 	}
 }
 
@@ -102,6 +104,7 @@ func (m ColumnsHazardsMap) Meta() Metadata {
 		Name:        "hz_columns",
 		Description: "Creates a static map on turn 0 that fills in odd squares, i.e. (1,1), (1,3), (3,3) ... with hazard sauce",
 		Author:      "Battlesnake",
+		Version:     "0.1.0",
 	}
 }
 
@@ -136,7 +139,8 @@ func (m SpiralHazardsMap) Meta() Metadata {
 		Name: "hz_spiral",
 		Description: `Generates a dynamic hazard map that grows in a spiral pattern clockwise from a random point on
  the map. Each 2 turns a new hazard square is added to the map`,
-		Author: "altersaddle",
+		Author:  "altersaddle",
+		Version: "0.1.0",
 	}
 }
 
@@ -225,6 +229,7 @@ func (m ScatterFillMap) Meta() Metadata {
 	return Metadata{
 		Name:        "hz_scatter",
 		Description: `Fills the entire board with hazard squares that are set to appear on regular turn schedule. Each square is picked at random.`,
+		Version:     "0.1.0",
 	}
 }
 
@@ -272,6 +277,7 @@ func (m DirectionalExpandingBoxMap) Meta() Metadata {
 	return Metadata{
 		Name:        "hz_grow_box",
 		Description: `Creates an area of hazard that expands from a point with one random side growing on a turn schedule.`,
+		Version:     "0.1.0",
 	}
 }
 
@@ -382,6 +388,7 @@ func (m ExpandingBoxMap) Meta() Metadata {
 	return Metadata{
 		Name:        "hz_expand_box",
 		Description: `Generates an area of hazard that expands from a random point on the board outward in concentric rings on a periodic turn schedule.`,
+		Version:     "0.1.0",
 	}
 }
 
@@ -453,6 +460,7 @@ func (m ExpandingScatterMap) Meta() Metadata {
 	return Metadata{
 		Name:        "hz_expand_scatter",
 		Description: `Builds an expanding hazard area that grows from a central point in rings that are randomly filled in on a regular turn schedule.`,
+		Version:     "0.1.0",
 	}
 }
 
@@ -530,7 +538,8 @@ func (m RiverAndBridgesHazardsMap) Meta() Metadata {
 		Name: "hz_rivers_bridges",
 		Description: `Creates fixed maps that have a lake of hazard in the middle with rivers going in the cardinal directions.
 Each river has one or two 1-square "bridges" over them`,
-		Author: "Battlesnake",
+		Author:  "Battlesnake",
+		Version: "0.1.0",
 	}
 }
 

--- a/maps/registry_test.go
+++ b/maps/registry_test.go
@@ -1,6 +1,7 @@
 package maps
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/BattlesnakeOfficial/rules"
@@ -22,7 +23,7 @@ func TestRegisteredMaps(t *testing.T) {
 	for mapName, gameMap := range globalRegistry {
 		t.Run(mapName, func(t *testing.T) {
 			require.Equalf(t, mapName, gameMap.ID(), "%#v game map doesn't return its own ID", mapName)
-
+			require.True(t, gameMap.Meta().Version.IsValid(), fmt.Sprintf("registered maps must have a valid version - '%s' is not valid a semver string", gameMap.Meta().Version))
 			var setupBoardState *rules.BoardState
 
 			for width := 0; width < maxBoardWidth; width++ {

--- a/maps/registry_test.go
+++ b/maps/registry_test.go
@@ -23,7 +23,7 @@ func TestRegisteredMaps(t *testing.T) {
 	for mapName, gameMap := range globalRegistry {
 		t.Run(mapName, func(t *testing.T) {
 			require.Equalf(t, mapName, gameMap.ID(), "%#v game map doesn't return its own ID", mapName)
-			require.True(t, gameMap.Meta().Version.IsValid(), fmt.Sprintf("registered maps must have a valid version - '%s' is not valid a semver string", gameMap.Meta().Version))
+			require.True(t, gameMap.Meta().Version > 0, fmt.Sprintf("registered maps must have a valid version (>= 1) - '%d' is invalid", gameMap.Meta().Version))
 			var setupBoardState *rules.BoardState
 
 			for width := 0; width < maxBoardWidth; width++ {

--- a/maps/royale.go
+++ b/maps/royale.go
@@ -21,6 +21,7 @@ func (m RoyaleHazardsMap) Meta() Metadata {
 		Name:        "Royale",
 		Description: "A map where hazards are generated every N turns",
 		Author:      "Battlesnake",
+		Version:     "0.1.0",
 	}
 }
 

--- a/maps/royale.go
+++ b/maps/royale.go
@@ -21,7 +21,7 @@ func (m RoyaleHazardsMap) Meta() Metadata {
 		Name:        "Royale",
 		Description: "A map where hazards are generated every N turns",
 		Author:      "Battlesnake",
-		Version:     "0.1.0",
+		Version:     1,
 	}
 }
 

--- a/maps/standard.go
+++ b/maps/standard.go
@@ -19,7 +19,7 @@ func (m StandardMap) Meta() Metadata {
 		Name:        "Standard",
 		Description: "Standard snake placement and food spawning",
 		Author:      "Battlesnake",
-		Version:     "0.1.0",
+		Version:     1,
 	}
 }
 

--- a/maps/standard.go
+++ b/maps/standard.go
@@ -19,6 +19,7 @@ func (m StandardMap) Meta() Metadata {
 		Name:        "Standard",
 		Description: "Standard snake placement and food spawning",
 		Author:      "Battlesnake",
+		Version:     "0.1.0",
 	}
 }
 


### PR DESCRIPTION
Adds a new "Version" field to the GameMap Metadata type. The value is the **current** version of the map. When changes are made, the version number should be incremented by `1`. All versions should start at `1`. The game map registry has a test to ensure that versions are valid.