### PR TITLE
fix for readme, install as go package.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Download precompiled binaries here: <br>
 
 Install as a Go package. Requires Go 1.18 or higher. [[Download](https://golang.org/dl/)]
 ```
-go get github.com/BattlesnakeOfficial/rules/cli/battlesnake
+go install github.com/BattlesnakeOfficial/rules/cli/battlesnake@latest
 ```
 
 Compile from source. Also requires Go 1.18 or higher.


### PR DESCRIPTION
go get is no longer supported outside a module, the command line recommended go install. go install requires a version,  that is why @latest is at the end. First, pull request ever, open to feedback on formatting.