### PR TITLE
allow initial food placement for 8 snakes on 7x7 board

### DIFF
--- a/board.go
+++ b/board.go
@@ -216,7 +216,7 @@ func PlaceFoodFixed(rand Rand, b *BoardState) error {
 	isSmallBoard := b.Width*b.Height <= 49
 	// Up to 7 snakes can be placed such that food is nearby on small boards.
 	// Otherwise, we skip this and only try to place food in the center.
-	if len(b.Snakes) <= 7 && isSmallBoard {
+	if len(b.Snakes) <= 7 || !isSmallBoard {
 		// Place 1 food within exactly 2 moves of each snake, but never towards the center or in a corner
 		for i := 0; i < len(b.Snakes); i++ {
 			snakeHead := b.Snakes[i].Body[0]

--- a/board.go
+++ b/board.go
@@ -213,10 +213,10 @@ func PlaceFoodAutomatically(rand Rand, b *BoardState) error {
 func PlaceFoodFixed(rand Rand, b *BoardState) error {
 	centerCoord := Point{(b.Width - 1) / 2, (b.Height - 1) / 2}
 
-	isSmallBoard := b.Width*b.Height <= 49
-	// Up to 7 snakes can be placed such that food is nearby on small boards.
+	isSmallBoard := b.Width*b.Height <= BoardSizeSmall*BoardSizeSmall
+	// Up to 4 snakes can be placed such that food is nearby on small boards.
 	// Otherwise, we skip this and only try to place food in the center.
-	if len(b.Snakes) <= 7 || !isSmallBoard {
+	if len(b.Snakes) <= 4 || !isSmallBoard {
 		// Place 1 food within exactly 2 moves of each snake, but never towards the center or in a corner
 		for i := 0; i < len(b.Snakes); i++ {
 			snakeHead := b.Snakes[i].Body[0]

--- a/board.go
+++ b/board.go
@@ -213,9 +213,10 @@ func PlaceFoodAutomatically(rand Rand, b *BoardState) error {
 func PlaceFoodFixed(rand Rand, b *BoardState) error {
 	centerCoord := Point{(b.Width - 1) / 2, (b.Height - 1) / 2}
 
-	// Up to 7 snakes can be placed such that food is nearby.
+	isSmallBoard := b.Width*b.Height <= 49
+	// Up to 7 snakes can be placed such that food is nearby on small boards.
 	// Otherwise, we skip this and only try to place food in the center.
-	if len(b.Snakes) <= 7 {
+	if len(b.Snakes) <= 7 && isSmallBoard {
 		// Place 1 food within exactly 2 moves of each snake, but never towards the center or in a corner
 		for i := 0; i < len(b.Snakes); i++ {
 			snakeHead := b.Snakes[i].Body[0]

--- a/board_test.go
+++ b/board_test.go
@@ -9,10 +9,31 @@ import (
 )
 
 func TestDev1235(t *testing.T) {
-	_, err := CreateDefaultBoardState(MaxRand, 7, 7, []string{
+	// Small boards should no longer error and only get 1 food when num snakes > 4
+	state, err := CreateDefaultBoardState(MaxRand, BoardSizeSmall, BoardSizeSmall, []string{
 		"1", "2", "3", "4", "5", "6", "7", "8",
 	})
 	require.NoError(t, err)
+	require.Len(t, state.Food, 1)
+	state, err = CreateDefaultBoardState(MaxRand, BoardSizeSmall, BoardSizeSmall, []string{
+		"1", "2", "3", "4", "5",
+	})
+	require.NoError(t, err)
+	require.Len(t, state.Food, 1)
+
+	// Small boards with <= 4 snakes should still get more than just center food
+	state, err = CreateDefaultBoardState(MaxRand, BoardSizeSmall, BoardSizeSmall, []string{
+		"1", "2", "3", "4",
+	})
+	require.NoError(t, err)
+	require.Len(t, state.Food, 5)
+
+	// Medium boards should still get 9 food
+	state, err = CreateDefaultBoardState(MaxRand, BoardSizeMedium, BoardSizeMedium, []string{
+		"1", "2", "3", "4", "5", "6", "7", "8",
+	})
+	require.NoError(t, err)
+	require.Len(t, state.Food, 9)
 }
 
 func sortPoints(p []Point) {

--- a/board_test.go
+++ b/board_test.go
@@ -8,6 +8,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDev1235(t *testing.T) {
+	_, err := CreateDefaultBoardState(MaxRand, 7, 7, []string{
+		"1", "2", "3", "4", "5", "6", "7", "8",
+	})
+	require.NoError(t, err)
+}
+
 func sortPoints(p []Point) {
 	sort.Slice(p, func(i, j int) bool {
 		if p[i].X != p[j].X {


### PR DESCRIPTION
Food placement logic is altered such that small boards (7x7 or smaller) that have > 4 snakes will only spawn food in the center. This avoids a possible edge case in the original logic where the food placement for nearby snakes can overlap and throw an error.