### PR TITLE
Add decay logic to healing pools

### DIFF
--- a/maps/healing_pools.go
+++ b/maps/healing_pools.go
@@ -54,7 +54,7 @@ func (m HealingPoolsMap) UpdateBoard(lastBoardState *rules.BoardState, settings 
 		return err
 	}
 
-	if lastBoardState.Turn > 0 && len(lastBoardState.Hazards) > 0 && lastBoardState.Turn%settings.RoyaleSettings.ShrinkEveryNTurns == 0 {
+	if lastBoardState.Turn > 0 && settings.RoyaleSettings.ShrinkEveryNTurns > 0 && len(lastBoardState.Hazards) > 0 && lastBoardState.Turn%settings.RoyaleSettings.ShrinkEveryNTurns == 0 {
 		// Attempt to remove a healing pool every ShrinkEveryNTurns until there are none remaining
 		i := rand.Intn(len(lastBoardState.Hazards))
 		editor.RemoveHazard(lastBoardState.Hazards[i])

--- a/maps/healing_pools.go
+++ b/maps/healing_pools.go
@@ -1,6 +1,8 @@
 package maps
 
 import (
+	"math/rand"
+
 	"github.com/BattlesnakeOfficial/rules"
 )
 
@@ -48,7 +50,17 @@ func (m HealingPoolsMap) SetupBoard(initialBoardState *rules.BoardState, setting
 }
 
 func (m HealingPoolsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-	return StandardMap{}.UpdateBoard(lastBoardState, settings, editor)
+	if err := (StandardMap{}).UpdateBoard(lastBoardState, settings, editor); err != nil {
+		return err
+	}
+
+	if lastBoardState.Turn > 0 && len(lastBoardState.Hazards) > 0 && lastBoardState.Turn%settings.RoyaleSettings.ShrinkEveryNTurns == 0 {
+		// Attempt to remove a healing pool every ShrinkEveryNTurns until there are none remaining
+		i := rand.Intn(len(lastBoardState.Hazards))
+		editor.RemoveHazard(lastBoardState.Hazards[i])
+	}
+
+	return nil
 }
 
 var poolLocationOptions = map[rules.Point][][]rules.Point{

--- a/maps/healing_pools_test.go
+++ b/maps/healing_pools_test.go
@@ -41,8 +41,9 @@ func TestHealingPoolsMap(t *testing.T) {
 			m := maps.HealingPoolsMap{}
 			state := rules.NewBoardState(tc.boardSize, tc.boardSize)
 			settings := rules.Settings{}
+			settings.RoyaleSettings.ShrinkEveryNTurns = 10
 
-			// ensure the ring of hazards is added to the board at setup
+			// ensure the hazards are added to the board at setup
 			editor := maps.NewBoardStateEditor(state)
 			require.Empty(t, state.Hazards)
 			err := m.SetupBoard(state, settings, editor)
@@ -53,6 +54,16 @@ func TestHealingPoolsMap(t *testing.T) {
 			for _, p := range state.Hazards {
 				require.Contains(t, tc.allowableHazards, p)
 			}
+
+			// ensure the hazards are removed
+			totalTurns := settings.RoyaleSettings.ShrinkEveryNTurns*tc.expectedHazards + 1
+			for i := 0; i < totalTurns; i++ {
+				state.Turn = i
+				err = m.UpdateBoard(state, settings, editor)
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, 0, len(state.Hazards))
 		})
 	}
 }


### PR DESCRIPTION
Healing pools are now removed one at a time based on the RoyaleSettings.ShrinkEveryNTurns setting