### PR TITLE
Add PreUpdateBoard to the Map Interface

### DIFF
--- a/cli/commands/play.go
+++ b/cli/commands/play.go
@@ -374,7 +374,12 @@ func (gameState *GameState) createNextBoardState(boardState *rules.BoardState) *
 		snakeState.LastMove = move.Move
 		gameState.snakeStates[move.ID] = snakeState
 	}
-	boardState, err := gameState.ruleset.CreateNextBoardState(boardState, moves)
+  boardState, err := maps.PreUpdateBoard(gameState.gameMap.ID(), boardState, gameState.ruleset.Settings())
+	if err != nil {
+		log.Fatalf("Error updating board with game map: %v", err)
+	}
+
+	boardState, err = gameState.ruleset.CreateNextBoardState(boardState, moves)
 	if err != nil {
 		log.Fatalf("Error producing next board state: %v", err)
 	}

--- a/cli/commands/play.go
+++ b/cli/commands/play.go
@@ -374,7 +374,7 @@ func (gameState *GameState) createNextBoardState(boardState *rules.BoardState) *
 		snakeState.LastMove = move.Move
 		gameState.snakeStates[move.ID] = snakeState
 	}
-  boardState, err := maps.PreUpdateBoard(gameState.gameMap.ID(), boardState, gameState.ruleset.Settings())
+	boardState, err := maps.PreUpdateBoard(gameState.gameMap.ID(), boardState, gameState.ruleset.Settings())
 	if err != nil {
 		log.Fatalf("Error updating board with game map: %v", err)
 	}

--- a/maps/arcade_maze.go
+++ b/maps/arcade_maze.go
@@ -68,6 +68,10 @@ func (m ArcadeMazeMap) SetupBoard(initialBoardState *rules.BoardState, settings 
 	return nil
 }
 
+func (m ArcadeMazeMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+  return nil
+}
+
 func (m ArcadeMazeMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	rand := settings.GetRand(lastBoardState.Turn)
 

--- a/maps/arcade_maze.go
+++ b/maps/arcade_maze.go
@@ -69,7 +69,7 @@ func (m ArcadeMazeMap) SetupBoard(initialBoardState *rules.BoardState, settings 
 }
 
 func (m ArcadeMazeMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-  return nil
+	return nil
 }
 
 func (m ArcadeMazeMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {

--- a/maps/empty.go
+++ b/maps/empty.go
@@ -55,3 +55,7 @@ func (m EmptyMap) SetupBoard(initialBoardState *rules.BoardState, settings rules
 func (m EmptyMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	return nil
 }
+
+func (m EmptyMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+  return nil
+}

--- a/maps/empty.go
+++ b/maps/empty.go
@@ -57,5 +57,5 @@ func (m EmptyMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.S
 }
 
 func (m EmptyMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-  return nil
+	return nil
 }

--- a/maps/game_map.go
+++ b/maps/game_map.go
@@ -16,6 +16,9 @@ type GameMap interface {
 
 	// Called every turn to optionally update the board.
 	UpdateBoard(previousBoardState *rules.BoardState, settings rules.Settings, editor Editor) error
+
+	// Called every turn to optionally update the board.
+	PreUpdateBoard(previousBoardState *rules.BoardState, settings rules.Settings, editor Editor) error
 }
 
 // Dimensions describes the size of a Battlesnake board.

--- a/maps/game_map.go
+++ b/maps/game_map.go
@@ -17,7 +17,8 @@ type GameMap interface {
 	// Called every turn to optionally update the board.
 	UpdateBoard(previousBoardState *rules.BoardState, settings rules.Settings, editor Editor) error
 
-	// Called every turn to optionally update the board.
+	// Called every turn BEFORE the new moves are applies to optionally update the board
+	// Things changed in this function will take effect this turn
 	PreUpdateBoard(previousBoardState *rules.BoardState, settings rules.Settings, editor Editor) error
 }
 

--- a/maps/hazards.go
+++ b/maps/hazards.go
@@ -54,6 +54,10 @@ func (m InnerBorderHazardsMap) SetupBoard(lastBoardState *rules.BoardState, sett
 	return nil
 }
 
+func (m InnerBorderHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+  return nil
+}
+
 func (m InnerBorderHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	return StandardMap{}.UpdateBoard(lastBoardState, settings, editor)
 }
@@ -95,6 +99,10 @@ func (m ConcentricRingsHazardsMap) SetupBoard(lastBoardState *rules.BoardState, 
 	return nil
 }
 
+func (m ConcentricRingsHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
 func (m ConcentricRingsHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	return StandardMap{}.UpdateBoard(lastBoardState, settings, editor)
 }
@@ -133,6 +141,10 @@ func (m ColumnsHazardsMap) SetupBoard(lastBoardState *rules.BoardState, settings
 	return nil
 }
 
+func (m ColumnsHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+  return nil
+}
+
 func (m ColumnsHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	return StandardMap{}.UpdateBoard(lastBoardState, settings, editor)
 }
@@ -158,6 +170,10 @@ func (m SpiralHazardsMap) Meta() Metadata {
 
 func (m SpiralHazardsMap) SetupBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	return (StandardMap{}).SetupBoard(lastBoardState, settings, editor)
+}
+
+func (m SpiralHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
 }
 
 func (m SpiralHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
@@ -252,6 +268,10 @@ func (m ScatterFillMap) SetupBoard(lastBoardState *rules.BoardState, settings ru
 	return (StandardMap{}).SetupBoard(lastBoardState, settings, editor)
 }
 
+func (m ScatterFillMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
 func (m ScatterFillMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	err := StandardMap{}.UpdateBoard(lastBoardState, settings, editor)
 	if err != nil {
@@ -301,6 +321,10 @@ func (m DirectionalExpandingBoxMap) Meta() Metadata {
 
 func (m DirectionalExpandingBoxMap) SetupBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	return (StandardMap{}).SetupBoard(lastBoardState, settings, editor)
+}
+
+func (m DirectionalExpandingBoxMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
 }
 
 func (m DirectionalExpandingBoxMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
@@ -417,6 +441,10 @@ func (m ExpandingBoxMap) SetupBoard(lastBoardState *rules.BoardState, settings r
 	return (StandardMap{}).SetupBoard(lastBoardState, settings, editor)
 }
 
+func (m ExpandingBoxMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
 func (m ExpandingBoxMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	err := StandardMap{}.UpdateBoard(lastBoardState, settings, editor)
 	if err != nil {
@@ -490,6 +518,10 @@ func (m ExpandingScatterMap) Meta() Metadata {
 
 func (m ExpandingScatterMap) SetupBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	return (StandardMap{}).SetupBoard(lastBoardState, settings, editor)
+}
+
+func (m ExpandingScatterMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+  return nil
 }
 
 func (m ExpandingScatterMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
@@ -632,6 +664,10 @@ func (m RiverAndBridgesHazardsMap) SetupBoard(lastBoardState *rules.BoardState, 
 	}
 
 	return nil
+}
+
+func (m RiverAndBridgesHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+  return nil
 }
 
 func (m RiverAndBridgesHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {

--- a/maps/hazards.go
+++ b/maps/hazards.go
@@ -55,7 +55,7 @@ func (m InnerBorderHazardsMap) SetupBoard(lastBoardState *rules.BoardState, sett
 }
 
 func (m InnerBorderHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-  return nil
+	return nil
 }
 
 func (m InnerBorderHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
@@ -142,7 +142,7 @@ func (m ColumnsHazardsMap) SetupBoard(lastBoardState *rules.BoardState, settings
 }
 
 func (m ColumnsHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-  return nil
+	return nil
 }
 
 func (m ColumnsHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
@@ -521,7 +521,7 @@ func (m ExpandingScatterMap) SetupBoard(lastBoardState *rules.BoardState, settin
 }
 
 func (m ExpandingScatterMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-  return nil
+	return nil
 }
 
 func (m ExpandingScatterMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
@@ -667,7 +667,7 @@ func (m RiverAndBridgesHazardsMap) SetupBoard(lastBoardState *rules.BoardState, 
 }
 
 func (m RiverAndBridgesHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-  return nil
+	return nil
 }
 
 func (m RiverAndBridgesHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {

--- a/maps/healing_pools.go
+++ b/maps/healing_pools.go
@@ -27,7 +27,7 @@ func (m HealingPoolsMap) Meta() Metadata {
 }
 
 func (m HealingPoolsMap) PreUpdateBoard(initialBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-  return nil
+	return nil
 }
 
 func (m HealingPoolsMap) SetupBoard(initialBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {

--- a/maps/healing_pools.go
+++ b/maps/healing_pools.go
@@ -26,6 +26,10 @@ func (m HealingPoolsMap) Meta() Metadata {
 	}
 }
 
+func (m HealingPoolsMap) PreUpdateBoard(initialBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+  return nil
+}
+
 func (m HealingPoolsMap) SetupBoard(initialBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	if err := (StandardMap{}).SetupBoard(initialBoardState, settings, editor); err != nil {
 		return err

--- a/maps/helpers.go
+++ b/maps/helpers.go
@@ -95,6 +95,10 @@ func (m StubMap) SetupBoard(initialBoardState *rules.BoardState, settings rules.
 	return nil
 }
 
+func (m StubMap) PreUpdateBoard(previousBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
 func (m StubMap) UpdateBoard(previousBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	if m.Error != nil {
 		return m.Error

--- a/maps/helpers.go
+++ b/maps/helpers.go
@@ -26,6 +26,24 @@ func SetupBoard(mapID string, settings rules.Settings, width, height int, snakeI
 }
 
 //  UpdateBoard is a shortcut for looking up a map by ID and updating an existing board state with it.
+func PreUpdateBoard(mapID string, previousBoardState *rules.BoardState, settings rules.Settings) (*rules.BoardState, error) {
+	gameMap, err := GetMap(mapID)
+	if err != nil {
+		return nil, err
+	}
+
+	nextBoardState := previousBoardState.Clone()
+	editor := NewBoardStateEditor(nextBoardState)
+
+	err = gameMap.PreUpdateBoard(previousBoardState, settings, editor)
+	if err != nil {
+		return nil, err
+	}
+
+	return nextBoardState, nil
+}
+
+//  UpdateBoard is a shortcut for looking up a map by ID and updating an existing board state with it.
 func UpdateBoard(mapID string, previousBoardState *rules.BoardState, settings rules.Settings) (*rules.BoardState, error) {
 	gameMap, err := GetMap(mapID)
 	if err != nil {

--- a/maps/royale.go
+++ b/maps/royale.go
@@ -32,6 +32,10 @@ func (m RoyaleHazardsMap) SetupBoard(lastBoardState *rules.BoardState, settings 
 	return StandardMap{}.SetupBoard(lastBoardState, settings, editor)
 }
 
+func (m RoyaleHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+  return nil
+}
+
 func (m RoyaleHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	// Use StandardMap to populate food
 	if err := (StandardMap{}).UpdateBoard(lastBoardState, settings, editor); err != nil {

--- a/maps/royale.go
+++ b/maps/royale.go
@@ -33,7 +33,7 @@ func (m RoyaleHazardsMap) SetupBoard(lastBoardState *rules.BoardState, settings 
 }
 
 func (m RoyaleHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-  return nil
+	return nil
 }
 
 func (m RoyaleHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {

--- a/maps/sinkholes.go
+++ b/maps/sinkholes.go
@@ -32,6 +32,10 @@ func (m SinkholesMap) SetupBoard(initialBoardState *rules.BoardState, settings r
 	return (StandardMap{}).SetupBoard(initialBoardState, settings, editor)
 }
 
+func (m SinkholesMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+  return nil
+}
+
 func (m SinkholesMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	err := StandardMap{}.UpdateBoard(lastBoardState, settings, editor)
 	if err != nil {

--- a/maps/sinkholes.go
+++ b/maps/sinkholes.go
@@ -33,7 +33,7 @@ func (m SinkholesMap) SetupBoard(initialBoardState *rules.BoardState, settings r
 }
 
 func (m SinkholesMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-  return nil
+	return nil
 }
 
 func (m SinkholesMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {

--- a/maps/solo_maze.go
+++ b/maps/solo_maze.go
@@ -175,6 +175,10 @@ func (m SoloMazeMap) PlaceFood(boardState *rules.BoardState, settings rules.Sett
 	}
 }
 
+func (m SoloMazeMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+  return nil
+}
+
 func (m SoloMazeMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	currentLevel, e := m.ReadBitState(lastBoardState)
 	if e != nil {

--- a/maps/solo_maze.go
+++ b/maps/solo_maze.go
@@ -176,7 +176,7 @@ func (m SoloMazeMap) PlaceFood(boardState *rules.BoardState, settings rules.Sett
 }
 
 func (m SoloMazeMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-  return nil
+	return nil
 }
 
 func (m SoloMazeMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {

--- a/maps/standard.go
+++ b/maps/standard.go
@@ -27,7 +27,7 @@ func (m StandardMap) Meta() Metadata {
 }
 
 func (m StandardMap) PreUpdateBoard(initialBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-  return nil
+	return nil
 }
 
 func (m StandardMap) SetupBoard(initialBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {

--- a/maps/standard.go
+++ b/maps/standard.go
@@ -26,6 +26,10 @@ func (m StandardMap) Meta() Metadata {
 	}
 }
 
+func (m StandardMap) PreUpdateBoard(initialBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+  return nil
+}
+
 func (m StandardMap) SetupBoard(initialBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	rand := settings.GetRand(0)
 

--- a/maps/test.go
+++ b/maps/test.go
@@ -53,24 +53,24 @@ func (m TestHealthMap) SetupBoard(initialBoardState *rules.BoardState, settings 
 }
 
 func (m TestHealthMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-  if lastBoardState.Turn == 30 {
-    snake := lastBoardState.Snakes[0]
-    editor.PlaceSnake(snake.ID, snake.Body, 0)
-  }
+	if lastBoardState.Turn == 30 {
+		snake := lastBoardState.Snakes[0]
+		editor.PlaceSnake(snake.ID, snake.Body, 0)
+	}
 
 	return nil
 }
 
 func (m TestHealthMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-  if lastBoardState.Turn == 20 {
-    snake := lastBoardState.Snakes[0]
-    head := snake.Body[0]
+	if lastBoardState.Turn == 20 {
+		snake := lastBoardState.Snakes[0]
+		head := snake.Body[0]
 
-    editor.AddHazard(rules.Point{X: head.X + 1, Y: head.Y})
-    editor.AddHazard(rules.Point{X: head.X - 1, Y: head.Y})
-    editor.AddHazard(rules.Point{X: head.X, Y: head.Y + 1})
-    editor.AddHazard(rules.Point{X: head.X, Y: head.Y - 1})
-  }
+		editor.AddHazard(rules.Point{X: head.X + 1, Y: head.Y})
+		editor.AddHazard(rules.Point{X: head.X - 1, Y: head.Y})
+		editor.AddHazard(rules.Point{X: head.X, Y: head.Y + 1})
+		editor.AddHazard(rules.Point{X: head.X, Y: head.Y - 1})
+	}
 
 	return nil
 }

--- a/maps/test.go
+++ b/maps/test.go
@@ -1,0 +1,76 @@
+package maps
+
+import (
+	"github.com/BattlesnakeOfficial/rules"
+)
+
+type TestHealthMap struct{}
+
+func init() {
+	globalRegistry.RegisterMap("test_health", TestHealthMap{})
+}
+
+func (m TestHealthMap) ID() string {
+	return "test_health"
+}
+
+func (m TestHealthMap) Meta() Metadata {
+	return Metadata{
+		Name:        "Empty",
+		Description: "Default snake placement with no food",
+		Author:      "Battlesnake",
+		Version:     2,
+		MinPlayers:  1,
+		MaxPlayers:  16,
+		BoardSizes:  OddSizes(rules.BoardSizeSmall, rules.BoardSizeXXLarge),
+	}
+}
+
+func (m TestHealthMap) SetupBoard(initialBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	rand := settings.GetRand(0)
+
+	if len(initialBoardState.Snakes) > int(m.Meta().MaxPlayers) {
+		return rules.ErrorTooManySnakes
+	}
+
+	snakeIDs := make([]string, 0, len(initialBoardState.Snakes))
+	for _, snake := range initialBoardState.Snakes {
+		snakeIDs = append(snakeIDs, snake.ID)
+	}
+
+	tempBoardState := rules.NewBoardState(initialBoardState.Width, initialBoardState.Height)
+	err := rules.PlaceSnakesAutomatically(rand, tempBoardState, snakeIDs)
+	if err != nil {
+		return err
+	}
+
+	// Copy snakes from temp board state
+	for _, snake := range tempBoardState.Snakes {
+		editor.PlaceSnake(snake.ID, snake.Body, snake.Health)
+	}
+
+	return nil
+}
+
+func (m TestHealthMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+  if lastBoardState.Turn == 30 {
+    snake := lastBoardState.Snakes[0]
+    editor.PlaceSnake(snake.ID, snake.Body, 0)
+  }
+
+	return nil
+}
+
+func (m TestHealthMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+  if lastBoardState.Turn == 20 {
+    snake := lastBoardState.Snakes[0]
+    head := snake.Body[0]
+
+    editor.AddHazard(rules.Point{X: head.X + 1, Y: head.Y})
+    editor.AddHazard(rules.Point{X: head.X - 1, Y: head.Y})
+    editor.AddHazard(rules.Point{X: head.X, Y: head.Y + 1})
+    editor.AddHazard(rules.Point{X: head.X, Y: head.Y - 1})
+  }
+
+	return nil
+}


### PR DESCRIPTION
One of the issues that we've seen is that its harder to design maps
since you only can make changes AFTER the normal game logic is applied.

Here we add a method to the interface (and a map to test it) that allows
maps to hook into the editor before the moves are applied.

This is useful if you want to spawn a hazard or food, and want to see it
take effect in the same turn

**This PR is here mostly for discussion, not that we are tried to this specific implementation at all.
I can also open a Discussion item if thats where we wanted to centralize convos**

Co-authored-by: JonathanArns <jonathan.arns@googlemail.com>