### PR TITLE
add 'map' cli command to provide map information

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -81,13 +81,13 @@ battlesnake play --width 7 --height 7 --name Snake1 --url http://snake1-url-what
 ### Maps
 The `map` command provides map information for use with the `play` command.
 
-List all available maps using the `--list` flag:
+List all available maps using the `list` subcommand:
 ```
-battlesnake map --list
+battlesnake map list
 ```
-Display map information using the `--info` flag:
+Display map information using the `info` subcommand:
 ```
-battlesnake map --info standard
+battlesnake map info standard
 Name: Standard
 Author: Battlesnake
 Description: Standard snake placement and food spawning

--- a/cli/README.md
+++ b/cli/README.md
@@ -78,6 +78,25 @@ Example creating a 7x7 Standard game with two Battlesnakes:
 battlesnake play --width 7 --height 7 --name Snake1 --url http://snake1-url-whatever --name Snake2 --url http://snake2-url-whatever
 ```
 
+### Maps
+The `map` command provides map information for use with the `play` command.
+
+List all available maps using the `--list` flag:
+```
+battlesnake map --list
+```
+Display map information using the `--info` flag:
+```
+battlesnake map --info standard
+Name: Standard
+Author: Battlesnake
+Description: Standard snake placement and food spawning
+Version: 2
+Min Players: 1
+Max Players: 16
+Board Sizes (WxH): 7x7 9x9 11x11 13x13 15x15 17x17 19x19 21x21 23x23 25x25
+```
+
 ### Sample Output
 ```
 $ battlesnake play --width 3 --height 3 --url http://redacted:4567/ --url http://redacted:4568/  --name Bob --name Sue

--- a/cli/commands/info.go
+++ b/cli/commands/info.go
@@ -1,0 +1,47 @@
+package commands
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/BattlesnakeOfficial/rules/maps"
+	"github.com/spf13/cobra"
+)
+
+func NewInfoCommand() *cobra.Command {
+	var infoCmd = &cobra.Command{
+		Use:   "info [flags] map_name [...map_name]",
+		Short: "Display metadata for given map(s)",
+		Long:  "Display metadata for given map(s)",
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) < 1 {
+				cmd.Help()
+			}
+			for i, m := range args {
+				gameMap, err := maps.GetMap(m)
+				if err != nil {
+					log.Fatalf("Failed to load game map %#v: %v", m, err)
+				}
+				meta := gameMap.Meta()
+				fmt.Println("Name:", meta.Name)
+				fmt.Println("Author:", meta.Author)
+				fmt.Println("Description:", meta.Description)
+				fmt.Println("Version:", meta.Version)
+				fmt.Println("Min Players:", meta.MinPlayers)
+				fmt.Println("Max Players:", meta.MaxPlayers)
+				fmt.Print("Board Sizes (WxH):")
+				for j, s := range meta.BoardSizes {
+					fmt.Printf(" %dx%d", s.Width, s.Height)
+					if j == (len(meta.BoardSizes) - 1) {
+						fmt.Print("\n")
+					}
+				}
+				// separate map information when querying multiple maps
+				if i < (len(args) - 1) {
+					fmt.Print("\n")
+				}
+			}
+		},
+	}
+	return infoCmd
+}

--- a/cli/commands/info.go
+++ b/cli/commands/info.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewInfoCommand() *cobra.Command {
+func NewMapInfoCommand() *cobra.Command {
 	var infoCmd = &cobra.Command{
 		Use:   "info [flags] map_name [...map_name]",
 		Short: "Display metadata for given map(s)",

--- a/cli/commands/info.go
+++ b/cli/commands/info.go
@@ -8,40 +8,68 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type mapInfo struct {
+	All bool
+}
+
 func NewMapInfoCommand() *cobra.Command {
+	info := mapInfo{}
 	var infoCmd = &cobra.Command{
 		Use:   "info [flags] map_name [...map_name]",
 		Short: "Display metadata for given map(s)",
 		Long:  "Display metadata for given map(s)",
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) < 1 {
-				cmd.Help()
-			}
-			for i, m := range args {
-				gameMap, err := maps.GetMap(m)
-				if err != nil {
-					log.Fatalf("Failed to load game map %#v: %v", m, err)
-				}
-				meta := gameMap.Meta()
-				fmt.Println("Name:", meta.Name)
-				fmt.Println("Author:", meta.Author)
-				fmt.Println("Description:", meta.Description)
-				fmt.Println("Version:", meta.Version)
-				fmt.Println("Min Players:", meta.MinPlayers)
-				fmt.Println("Max Players:", meta.MaxPlayers)
-				fmt.Print("Board Sizes (WxH):")
-				for j, s := range meta.BoardSizes {
-					fmt.Printf(" %dx%d", s.Width, s.Height)
-					if j == (len(meta.BoardSizes) - 1) {
+			// handle --all flag first as there would be no args
+			if info.All {
+				mapList := maps.List()
+				for i, m := range mapList {
+					info.display(m)
+					if i < (len(mapList) - 1) {
 						fmt.Print("\n")
 					}
 				}
-				// separate map information when querying multiple maps
+				return
+			}
+
+			// display help when no map(s) provided via args
+			if len(args) < 1 {
+				cmd.Help()
+				return
+			}
+
+			// display all maps via command args
+			for i, m := range args {
+				info.display(m)
 				if i < (len(args) - 1) {
 					fmt.Print("\n")
 				}
 			}
+
 		},
 	}
+
+	infoCmd.Flags().BoolVarP(&info.All, "all", "a", false, "Display information for all maps")
+
 	return infoCmd
+}
+
+func (m *mapInfo) display(id string) {
+	gameMap, err := maps.GetMap(id)
+	if err != nil {
+		log.Fatalf("Failed to load game map %#v: %v", id, err)
+	}
+	meta := gameMap.Meta()
+	fmt.Println("Name:", meta.Name)
+	fmt.Println("Author:", meta.Author)
+	fmt.Println("Description:", meta.Description)
+	fmt.Println("Version:", meta.Version)
+	fmt.Println("Min Players:", meta.MinPlayers)
+	fmt.Println("Max Players:", meta.MaxPlayers)
+	fmt.Print("Board Sizes (WxH):")
+	for i, s := range meta.BoardSizes {
+		fmt.Printf(" %dx%d", s.Width, s.Height)
+		if i == (len(meta.BoardSizes) - 1) {
+			fmt.Print("\n")
+		}
+	}
 }

--- a/cli/commands/info.go
+++ b/cli/commands/info.go
@@ -33,7 +33,10 @@ func NewMapInfoCommand() *cobra.Command {
 
 			// display help when no map(s) provided via args
 			if len(args) < 1 {
-				cmd.Help()
+				err := cmd.Help()
+				if err != nil {
+					log.Fatal(err)
+				}
 				return
 			}
 

--- a/cli/commands/list.go
+++ b/cli/commands/list.go
@@ -1,0 +1,22 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/BattlesnakeOfficial/rules/maps"
+	"github.com/spf13/cobra"
+)
+
+func NewListCommand() *cobra.Command {
+	var listCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List available game maps",
+		Long:  "List available game maps",
+		Run: func(cmd *cobra.Command, args []string) {
+			for _, m := range maps.List() {
+				fmt.Println(m)
+			}
+		},
+	}
+	return listCmd
+}

--- a/cli/commands/list.go
+++ b/cli/commands/list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewListCommand() *cobra.Command {
+func NewMapListCommand() *cobra.Command {
 	var listCmd = &cobra.Command{
 		Use:   "list",
 		Short: "List available game maps",

--- a/cli/commands/map.go
+++ b/cli/commands/map.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"log"
+
 	"github.com/spf13/cobra"
 )
 
@@ -11,7 +13,10 @@ func NewMapCommand() *cobra.Command {
 		Short: "Display map information",
 		Long:  "Display map information",
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
+			err := cmd.Help()
+			if err != nil {
+				log.Fatal(err)
+			}
 		},
 	}
 

--- a/cli/commands/map.go
+++ b/cli/commands/map.go
@@ -1,0 +1,62 @@
+package commands
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/BattlesnakeOfficial/rules/maps"
+	"github.com/spf13/cobra"
+)
+
+type mapCmdFlags struct {
+	List bool
+	Info string
+}
+
+func NewMapCommand() *cobra.Command {
+	mapFlags := &mapCmdFlags{}
+
+	var mapCmd = &cobra.Command{
+		Use:   "map",
+		Short: "Display map information",
+		Long:  "Display map information",
+		Run: func(cmd *cobra.Command, args []string) {
+			mapFlags.Process()
+		},
+	}
+
+	mapCmd.Flags().BoolVarP(&mapFlags.List, "list", "l", false, "List all available maps")
+	mapCmd.Flags().StringVarP(&mapFlags.Info, "info", "i", "", "Display metadata for given map")
+
+	mapCmd.Flags().SortFlags = false
+
+	return mapCmd
+}
+
+func (m *mapCmdFlags) Process() {
+
+	if m.List {
+		for _, m := range maps.List() {
+			fmt.Println(m)
+		}
+	}
+
+	if m.Info != "" {
+		gameMap, err := maps.GetMap(m.Info)
+		if err != nil {
+			log.Fatalf("Failed to load game map %#v: %v", m.Info, err)
+		}
+		meta := gameMap.Meta()
+		fmt.Println("Name:", meta.Name)
+		fmt.Println("Author:", meta.Author)
+		fmt.Println("Description:", meta.Description)
+		fmt.Println("Version:", meta.Version)
+		fmt.Println("Min Players:", meta.MinPlayers)
+		fmt.Println("Max Players:", meta.MaxPlayers)
+		fmt.Print("Board Sizes (WxH):")
+		for _, s := range meta.BoardSizes {
+			fmt.Printf(" %dx%d", s.Width, s.Height)
+		}
+		fmt.Print("\n")
+	}
+}

--- a/cli/commands/map.go
+++ b/cli/commands/map.go
@@ -1,62 +1,19 @@
 package commands
 
 import (
-	"fmt"
-	"log"
-
-	"github.com/BattlesnakeOfficial/rules/maps"
 	"github.com/spf13/cobra"
 )
 
-type mapCmdFlags struct {
-	List bool
-	Info string
-}
-
 func NewMapCommand() *cobra.Command {
-	mapFlags := &mapCmdFlags{}
 
 	var mapCmd = &cobra.Command{
 		Use:   "map",
 		Short: "Display map information",
 		Long:  "Display map information",
 		Run: func(cmd *cobra.Command, args []string) {
-			mapFlags.Process()
+			cmd.Help()
 		},
 	}
 
-	mapCmd.Flags().BoolVarP(&mapFlags.List, "list", "l", false, "List all available maps")
-	mapCmd.Flags().StringVarP(&mapFlags.Info, "info", "i", "", "Display metadata for given map")
-
-	mapCmd.Flags().SortFlags = false
-
 	return mapCmd
-}
-
-func (m *mapCmdFlags) Process() {
-
-	if m.List {
-		for _, m := range maps.List() {
-			fmt.Println(m)
-		}
-	}
-
-	if m.Info != "" {
-		gameMap, err := maps.GetMap(m.Info)
-		if err != nil {
-			log.Fatalf("Failed to load game map %#v: %v", m.Info, err)
-		}
-		meta := gameMap.Meta()
-		fmt.Println("Name:", meta.Name)
-		fmt.Println("Author:", meta.Author)
-		fmt.Println("Description:", meta.Description)
-		fmt.Println("Version:", meta.Version)
-		fmt.Println("Min Players:", meta.MinPlayers)
-		fmt.Println("Max Players:", meta.MaxPlayers)
-		fmt.Print("Board Sizes (WxH):")
-		for _, s := range meta.BoardSizes {
-			fmt.Printf(" %dx%d", s.Width, s.Height)
-		}
-		fmt.Print("\n")
-	}
 }

--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -20,6 +20,7 @@ var rootCmd = &cobra.Command{
 
 func Execute() {
 	rootCmd.AddCommand(NewPlayCommand())
+	rootCmd.AddCommand(NewMapCommand())
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -22,8 +22,8 @@ func Execute() {
 	rootCmd.AddCommand(NewPlayCommand())
 
 	mapCommand := NewMapCommand()
-	mapCommand.AddCommand(NewListCommand())
-	mapCommand.AddCommand(NewInfoCommand())
+	mapCommand.AddCommand(NewMapListCommand())
+	mapCommand.AddCommand(NewMapInfoCommand())
 
 	rootCmd.AddCommand(mapCommand)
 

--- a/cli/commands/root.go
+++ b/cli/commands/root.go
@@ -20,7 +20,12 @@ var rootCmd = &cobra.Command{
 
 func Execute() {
 	rootCmd.AddCommand(NewPlayCommand())
-	rootCmd.AddCommand(NewMapCommand())
+
+	mapCommand := NewMapCommand()
+	mapCommand.AddCommand(NewListCommand())
+	mapCommand.AddCommand(NewInfoCommand())
+
+	rootCmd.AddCommand(mapCommand)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/maps/registry.go
+++ b/maps/registry.go
@@ -2,6 +2,7 @@ package maps
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/BattlesnakeOfficial/rules"
 )
@@ -21,6 +22,16 @@ func (registry MapRegistry) RegisterMap(id string, m GameMap) {
 	registry[id] = m
 }
 
+// List returns all registered map IDs in alphabetical order
+func (registry MapRegistry) List() []string {
+	var keys []string
+	for k, _ := range registry {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 // GetMap returns the map associated with the given ID.
 func (registry MapRegistry) GetMap(id string) (GameMap, error) {
 	if m, ok := registry[id]; ok {
@@ -32,6 +43,11 @@ func (registry MapRegistry) GetMap(id string) (GameMap, error) {
 // GetMap returns the map associated with the given ID from the global registry.
 func GetMap(id string) (GameMap, error) {
 	return globalRegistry.GetMap(id)
+}
+
+// List returns a list of maps registered to the global registry.
+func List() []string {
+	return globalRegistry.List()
 }
 
 // RegisterMap adds a map to the global registry.

--- a/maps/registry_test.go
+++ b/maps/registry_test.go
@@ -112,3 +112,15 @@ func pickSize(meta Metadata) Dimensions {
 	// For fixed, just pick the first supported size
 	return meta.BoardSizes[0]
 }
+
+func TestListRegisteredMaps(t *testing.T) {
+	keys := globalRegistry.List()
+	mapCount := 0
+	for k := range globalRegistry {
+		// every registry key should exist in List results
+		require.Contains(t, keys, k)
+		mapCount++
+	}
+	// List should equal number of maps in the global registry
+	require.Equal(t, len(keys), mapCount)
+}


### PR DESCRIPTION
When a user downloads the binary distribution of the rules cli, it is not apparent as to what the names of the available maps are nor the supported board sizes and snake counts which are allowed for each map without digging into the source code.

This PR adds a new command `map` alongside `play`.

This command provides two subcommands initially:
- `battlesnake map list`
  - lists available map names
- `battlesnake map info <map name/id>`
  - Displays meta data for a given map including min/max snake count and supported board size

I understand that adding a new _top-level_ cobra command may be undesirable and may require future design discussions. I initially added to the "map not found" output; however, it seemed to fit better into its own command and allows for potential future extension.

edit: update examples to use subcommands instead of flags.