### PR TITLE
add tags to map info cli output

### DIFF
--- a/cli/commands/info.go
+++ b/cli/commands/info.go
@@ -75,4 +75,14 @@ func (m *mapInfo) display(id string) {
 			fmt.Print("\n")
 		}
 	}
+	fmt.Print("Tags:")
+	if len(meta.Tags) < 1 {
+		fmt.Print("\n")
+	}
+	for i, t := range meta.Tags {
+		fmt.Printf(" %s", t)
+		if i == (len(meta.Tags) - 1) {
+			fmt.Print("\n")
+		}
+	}
 }

--- a/maps/registry.go
+++ b/maps/registry.go
@@ -25,7 +25,7 @@ func (registry MapRegistry) RegisterMap(id string, m GameMap) {
 // List returns all registered map IDs in alphabetical order
 func (registry MapRegistry) List() []string {
 	var keys []string
-	for k, _ := range registry {
+	for k := range registry {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)


### PR DESCRIPTION
Update the `map info` cli command to display map metadata tags.