### PR TITLE
Hazard Pits Map

### DIFF
--- a/maps/hazard_pits.go
+++ b/maps/hazard_pits.go
@@ -27,7 +27,7 @@ func (m HazardPitsMap) Meta() Metadata {
 	}
 }
 
-func (m HazardPitsMap) AddHazardPits(board *rules.BoardState, settings rules.Settings, editor Editor) error {
+func (m HazardPitsMap) AddHazardPits(board *rules.BoardState, settings rules.Settings, editor Editor) {
 	for x := 0; x < board.Width; x++ {
 		for y := 0; y < board.Height; y++ {
 			if x%2 == 1 && y%2 == 1 {
@@ -44,7 +44,6 @@ func (m HazardPitsMap) AddHazardPits(board *rules.BoardState, settings rules.Set
 			}
 		}
 	}
-	return nil
 }
 
 func (m HazardPitsMap) SetupBoard(initialBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {

--- a/maps/hazard_pits.go
+++ b/maps/hazard_pits.go
@@ -1,0 +1,116 @@
+package maps
+
+import (
+	"github.com/BattlesnakeOfficial/rules"
+)
+
+func init() {
+	globalRegistry.RegisterMap("hz_hazard_pits", HazardPitsMap{})
+}
+
+type HazardPitsMap struct{}
+
+func (m HazardPitsMap) ID() string {
+	return "hz_hazard_pits"
+}
+
+func (m HazardPitsMap) Meta() Metadata {
+	return Metadata{
+		Name:        "hz_hazard_pits",
+		Description: "A map that that fills in grid-like pattern of squares with pits filled with hazard sauce. Every N turns the pits will fill with another layer of sauce. After 4 cycles the pits will drain and the process starts again",
+		Author:      "Battlesnake",
+		Version:     1,
+		MinPlayers:  1,
+		MaxPlayers:  4,
+		BoardSizes:  FixedSizes(Dimensions{11, 11}),
+		Tags:        []string{TAG_FOOD_PLACEMENT, TAG_HAZARD_PLACEMENT, TAG_SNAKE_PLACEMENT},
+	}
+}
+
+func (m HazardPitsMap) AddHazardPits(board *rules.BoardState, settings rules.Settings, editor Editor) error {
+	for x := 0; x < board.Width; x++ {
+		for y := 0; y < board.Height; y++ {
+			if x%2 == 1 && y%2 == 1 {
+				point := rules.Point{X: x, Y: y}
+				isStartPosition := false
+				for _, startPos := range hazardPitStartPositions {
+					if startPos == point {
+						isStartPosition = true
+					}
+				}
+				if !isStartPosition {
+					editor.AddHazard(point)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (m HazardPitsMap) SetupBoard(initialBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	rand := settings.GetRand(0)
+
+	rand.Shuffle(len(hazardPitStartPositions), func(i int, j int) {
+		hazardPitStartPositions[i], hazardPitStartPositions[j] = hazardPitStartPositions[j], hazardPitStartPositions[i]
+	})
+
+	// Place snakes
+	if len(initialBoardState.Snakes) > len(hazardPitStartPositions) {
+		return rules.ErrorTooManySnakes
+	}
+	for index, snake := range initialBoardState.Snakes {
+		head := hazardPitStartPositions[index]
+		editor.PlaceSnake(snake.ID, []rules.Point{head, head, head}, snake.Health)
+	}
+
+	err := rules.PlaceFoodFixed(rand, initialBoardState)
+	if err != nil {
+		return err
+	}
+
+	err = m.AddHazardPits(initialBoardState, settings, editor)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m HazardPitsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	err := StandardMap{}.UpdateBoard(lastBoardState, settings, editor)
+	if err != nil {
+		return err
+	}
+
+	if lastBoardState.Turn == 0 {
+		return nil
+	}
+	// Turn 0 = 1 layer of hazards
+	// Turn 1*<ShrinkEveryNTurns> = 2 layers of hazards
+	// Turn 2*<ShrinkEveryNTurns> = 3 layers of hazards
+	// Turn 3*<ShrinkEveryNTurns> = 4 layers of hazards
+	// Turn 4*<ShrinkEveryNTurns> = restart the cycle, 1 layers of hazards
+
+	if lastBoardState.Turn%settings.RoyaleSettings.ShrinkEveryNTurns == 0 {
+		// Time to change the hazards
+		phase := lastBoardState.Turn % 4
+
+		// clear all existing hazards
+		editor.ClearHazards()
+
+		// Add a layers of hazard pits depending on the phase
+		for n := 0; n < (phase + 1); n++ {
+			m.AddHazardPits(lastBoardState, settings, editor)
+		}
+
+		// Remove food from the pit when it is full of sauce?
+	}
+	return nil
+}
+
+var hazardPitStartPositions = []rules.Point{
+	{X: 1, Y: 1},
+	{X: 9, Y: 1},
+	{X: 1, Y: 9},
+	{X: 9, Y: 9},
+}

--- a/maps/hazard_pits.go
+++ b/maps/hazard_pits.go
@@ -91,18 +91,16 @@ func (m HazardPitsMap) UpdateBoard(lastBoardState *rules.BoardState, settings ru
 	// Turn 3*<ShrinkEveryNTurns> = 4 layers of hazards
 	// Turn 4*<ShrinkEveryNTurns> = restart the cycle, 1 layers of hazards
 
+	// Is it time to change the hazards
 	if lastBoardState.Turn%settings.RoyaleSettings.ShrinkEveryNTurns == 0 {
-		// Time to change the hazards
-		phase := lastBoardState.Turn % 4
+		layers := lastBoardState.Turn%4 + 1
 
-		// clear all existing hazards
 		editor.ClearHazards()
 
-		// Add a layers of hazard pits depending on the phase
-		for n := 0; n < (phase + 1); n++ {
+		// Add 1-4 layers of hazard pits depending on the turn
+		for n := 0; n < (layers + 1); n++ {
 			m.AddHazardPits(lastBoardState, settings, editor)
 		}
-
 		// Remove food from the pit when it is full of sauce?
 	}
 	return nil

--- a/maps/hazard_pits_test.go
+++ b/maps/hazard_pits_test.go
@@ -1,0 +1,70 @@
+package maps_test
+
+import (
+	"testing"
+
+	"github.com/BattlesnakeOfficial/rules"
+	"github.com/BattlesnakeOfficial/rules/maps"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHazardPitsMap(t *testing.T) {
+	// check error handling
+	m := maps.HazardPitsMap{}
+	settings := rules.Settings{}
+	// check error for unsupported board sizes
+	state := rules.NewBoardState(9,
+		9)
+	editor := maps.NewBoardStateEditor(state)
+	err := m.SetupBoard(state, settings, editor)
+	require.Error(t, err)
+
+	// too big
+	state = rules.NewBoardState(19, 19)
+	editor = maps.NewBoardStateEditor(state)
+	err = m.SetupBoard(state, settings, editor)
+	require.Error(t, err)
+
+	// Too many snakes
+	state = rules.NewBoardState(19, 19)
+	editor = maps.NewBoardStateEditor(state)
+	state.Snakes = append(state.Snakes, rules.Snake{ID: "1", Body: []rules.Point{}})
+	state.Snakes = append(state.Snakes, rules.Snake{ID: "2", Body: []rules.Point{}})
+	state.Snakes = append(state.Snakes, rules.Snake{ID: "3", Body: []rules.Point{}})
+	state.Snakes = append(state.Snakes, rules.Snake{ID: "4", Body: []rules.Point{}})
+	state.Snakes = append(state.Snakes, rules.Snake{ID: "5", Body: []rules.Point{}})
+	err = m.SetupBoard(state, settings, editor)
+	require.Error(t, err)
+
+	state = rules.NewBoardState(int(11), int(11))
+	m = maps.HazardPitsMap{}
+	settings.RoyaleSettings.ShrinkEveryNTurns = 1
+	editor = maps.NewBoardStateEditor(state)
+	require.Empty(t, state.Hazards)
+	err = m.SetupBoard(state, settings, editor)
+	require.NoError(t, err)
+	require.Empty(t, state.Hazards)
+	// Verify the hazard progression through the turns
+	for i := 0; i < 16; i++ {
+		state.Turn = i
+		err = m.UpdateBoard(state, settings, editor)
+		require.NoError(t, err)
+		if i == 1 {
+			require.Len(t, state.Hazards, 21)
+		} else if i == 2 {
+			require.Len(t, state.Hazards, 42)
+		} else if i == 3 {
+			require.Len(t, state.Hazards, 63)
+		} else if i == 4 {
+			require.Len(t, state.Hazards, 84)
+		} else if i == 5 {
+			require.Len(t, state.Hazards, 84)
+		} else if i == 6 {
+			require.Len(t, state.Hazards, 84)
+		} else if i == 7 {
+			require.Len(t, state.Hazards, 0)
+		} else if i == 8 {
+			require.Len(t, state.Hazards, 21)
+		}
+	}
+}


### PR DESCRIPTION
New 4-player map that that lays out a grid-like pattern of squares with pits filled with hazard sauce. Every N turns the pits will fill with another layer of sauce up to a maximum of 4 layers which last a few cycles, then the pits drain and the pattern repeats