### PR TITLE
DEV 1676: Add maps helper functions

### DIFF
--- a/maps/castle_wall.go
+++ b/maps/castle_wall.go
@@ -10,7 +10,7 @@ func init() {
 	globalRegistry.RegisterMap("hz_castle_wall_xl", CastleWallExtraLargeHazardsMap{})
 }
 
-func setupCastleWallBoard(maxPlayers uint, startingPositions []rules.Point, hazards []rules.Point, initialBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+func setupCastleWallBoard(maxPlayers int, startingPositions []rules.Point, hazards []rules.Point, initialBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	rand := settings.GetRand(initialBoardState.Turn)
 
 	if len(initialBoardState.Snakes) > int(maxPlayers) {

--- a/maps/castle_wall_test.go
+++ b/maps/castle_wall_test.go
@@ -21,8 +21,8 @@ func TestCastleWallHazardsMap(t *testing.T) {
 
 	tests := []struct {
 		Map    maps.GameMap
-		Width  uint
-		Height uint
+		Width  int
+		Height int
 	}{
 		{maps.CastleWallMediumHazardsMap{}, 11, 11},
 		{maps.CastleWallLargeHazardsMap{}, 19, 19},
@@ -31,7 +31,7 @@ func TestCastleWallHazardsMap(t *testing.T) {
 
 	// check all the supported sizes
 	for _, test := range tests {
-		state = rules.NewBoardState(int(test.Width), int(test.Height))
+		state = rules.NewBoardState(test.Width, test.Height)
 		state.Snakes = append(state.Snakes, rules.Snake{ID: "1", Body: []rules.Point{}})
 		editor = maps.NewBoardStateEditor(state)
 		require.Empty(t, state.Hazards)

--- a/maps/game_map.go
+++ b/maps/game_map.go
@@ -34,11 +34,11 @@ type Metadata struct {
 	Description string
 	// Version is the current version of the game map.
 	// Each time a map is changed, the version number should be incremented by 1.
-	Version uint
+	Version int
 	// MinPlayers is the minimum number of players that the map supports.
-	MinPlayers uint
+	MinPlayers int
 	// MaxPlayers is the maximum number of players that the map supports.
-	MaxPlayers uint
+	MaxPlayers int
 	// BoardSizes is a list of supported board sizes. Board sizes can fall into one of 3 categories:
 	//   1. one fixed size (i.e. [11x11])
 	//   2. multiple, fixed sizes (i.e. [11x11, 19x19, 25x25])
@@ -73,10 +73,10 @@ func (meta Metadata) Validate(boardState *rules.BoardState) error {
 type Dimensions struct {
 	// Width is the width, in number of board squares, of the board.
 	// The value 0 has a special meaning to mean unlimited.
-	Width uint
+	Width int
 	// Height is the height, in number of board squares, of the board.
 	// The value 0 has a special meaning to mean unlimited.
-	Height uint
+	Height int
 }
 
 // sizes is a list of board sizes that a map supports.
@@ -94,7 +94,7 @@ func (d sizes) IsAllowable(Width int, Height int) bool {
 	}
 
 	for _, size := range d {
-		if size.Width == uint(Width) && size.Height == uint(Height) {
+		if size.Width == Width && size.Height == Height {
 			return true
 		}
 	}
@@ -111,7 +111,7 @@ func AnySize() sizes {
 // in the vertical and horizontal directions.
 // Examples:
 //  - OddSizes(11,21) produces [(11,11), (13,13), (15,15), (17,17), (19,19), (21,21)]
-func OddSizes(min, max uint) sizes {
+func OddSizes(min, max int) sizes {
 	var s sizes
 	for i := min; i <= max; i += 2 {
 		s = append(s, Dimensions{Width: i, Height: i})

--- a/maps/game_map_test.go
+++ b/maps/game_map_test.go
@@ -7,6 +7,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestMapSizes(t *testing.T) {
+	s := FixedSizes(Dimensions{11, 12})
+	require.Equal(t, s[0].Width, uint(11))
+	require.Equal(t, s[0].Height, uint(12))
+
+	s = FixedSizes(Dimensions{11, 11}, Dimensions{19, 25})
+	require.Len(t, s, 2)
+	require.Equal(t, s[1].Width, uint(19))
+	require.Equal(t, s[1].Height, uint(25))
+
+	s = AnySize()
+	require.Len(t, s, 1, "unlimited maps should have just one dimensions")
+	require.True(t, s.IsUnlimited())
+}
+
 func TestBoardStateEditorInterface(t *testing.T) {
 	var _ Editor = (*BoardStateEditor)(nil)
 }
@@ -18,7 +33,7 @@ func TestBoardStateEditor(t *testing.T) {
 		Health: 100,
 	})
 
-	editor := BoardStateEditor{BoardState: boardState}
+	editor := BoardStateEditor{boardState: boardState}
 
 	editor.AddFood(rules.Point{X: 1, Y: 3})
 	editor.AddFood(rules.Point{X: 3, Y: 6})
@@ -56,6 +71,26 @@ func TestBoardStateEditor(t *testing.T) {
 		},
 	}, boardState)
 
+	require.Equal(t, []rules.Point{
+		{X: 1, Y: 3},
+		{X: 3, Y: 7},
+	}, editor.Food())
+
+	require.Equal(t, []rules.Point{
+		{X: 1, Y: 3},
+		{X: 3, Y: 7},
+	}, editor.Hazards())
+
+	require.Equal(t, map[string][]rules.Point{
+		"existing_snake": {
+			{X: 5, Y: 2}, {X: 5, Y: 1}, {X: 5, Y: 0},
+		},
+		"new_snake": {
+
+			{X: 0, Y: 0}, {X: 1, Y: 0}, {X: 1, Y: 1},
+		},
+	}, editor.SnakeBodies())
+
 	editor.ClearFood()
 	require.Equal(t, []rules.Point{}, boardState.Food)
 
@@ -63,17 +98,317 @@ func TestBoardStateEditor(t *testing.T) {
 	require.Equal(t, []rules.Point{}, boardState.Hazards)
 }
 
-func TestMapSizes(t *testing.T) {
-	s := FixedSizes(Dimensions{11, 12})
-	require.Equal(t, s[0].Width, uint(11))
-	require.Equal(t, s[0].Height, uint(12))
+func TestBoardStateEditorPlaceSnakesRandomlyAtPositions(t *testing.T) {
+	for label, test := range map[string]struct {
+		rand           rules.Rand
+		initialSnakes  []rules.Snake
+		heads          []rules.Point
+		bodyLength     int
+		expectedError  error
+		expectedSnakes []rules.Snake
+	}{
+		"empty": {
+			rules.MinRand,
+			[]rules.Snake{},
+			[]rules.Point{},
+			0,
+			nil,
+			[]rules.Snake{},
+		},
+		"too many snakes": {
+			rules.MinRand,
+			[]rules.Snake{
+				{ID: "1"}, {ID: "2"}, {ID: "3"},
+			},
+			[]rules.Point{{X: 3, Y: 3}, {X: 6, Y: 2}},
+			3,
+			rules.ErrorTooManySnakes,
+			nil,
+		},
+		"success unshuffled": {
+			rules.MinRand,
+			[]rules.Snake{
+				{ID: "1"}, {ID: "2"},
+			},
+			[]rules.Point{{X: 3, Y: 3}, {X: 6, Y: 2}},
+			3,
+			nil,
+			[]rules.Snake{
+				{
+					ID:     "1",
+					Body:   []rules.Point{{X: 3, Y: 3}, {X: 3, Y: 3}, {X: 3, Y: 3}},
+					Health: rules.SnakeMaxHealth,
+				}, {
+					ID:     "2",
+					Body:   []rules.Point{{X: 6, Y: 2}, {X: 6, Y: 2}, {X: 6, Y: 2}},
+					Health: rules.SnakeMaxHealth,
+				},
+			},
+		},
+		"success shuffled": {
+			rules.MaxRand,
+			[]rules.Snake{
+				{ID: "1"}, {ID: "2"},
+			},
+			[]rules.Point{{X: 3, Y: 3}, {X: 6, Y: 2}},
+			3,
+			nil,
+			[]rules.Snake{
+				{
+					ID:     "1",
+					Body:   []rules.Point{{X: 6, Y: 2}, {X: 6, Y: 2}, {X: 6, Y: 2}},
+					Health: rules.SnakeMaxHealth,
+				}, {
+					ID:     "2",
+					Body:   []rules.Point{{X: 3, Y: 3}, {X: 3, Y: 3}, {X: 3, Y: 3}},
+					Health: rules.SnakeMaxHealth,
+				},
+			},
+		},
+	} {
+		t.Run(label, func(t *testing.T) {
+			boardState := rules.NewBoardState(rules.BoardSizeSmall, rules.BoardSizeSmall)
+			boardState.Snakes = test.initialSnakes
+			editor := NewBoardStateEditor(boardState)
 
-	s = FixedSizes(Dimensions{11, 11}, Dimensions{19, 25})
-	require.Len(t, s, 2)
-	require.Equal(t, s[1].Width, uint(19))
-	require.Equal(t, s[1].Height, uint(25))
+			err := editor.PlaceSnakesRandomlyAtPositions(test.rand, test.initialSnakes, test.heads, test.bodyLength)
+			if test.expectedError != nil {
+				require.Equal(t, test.expectedError, err)
+			} else {
+				require.Equal(t, test.expectedSnakes, boardState.Snakes)
+			}
+		})
+	}
+}
 
-	s = AnySize()
-	require.Len(t, s, 1, "unlimited maps should have just one dimensions")
-	require.True(t, s.IsUnlimited())
+func TestBoardStateEditorIsOccupied(t *testing.T) {
+	for label, test := range map[string]struct {
+		boardState            *rules.BoardState
+		point                 rules.Point
+		snakes, hazards, food bool
+		expected              bool
+	}{
+		"empty board": {
+			rules.NewBoardState(rules.BoardSizeSmall, rules.BoardSizeSmall),
+			rules.Point{X: 3, Y: 3},
+			true, true, true,
+			false,
+		},
+		"unoccupied": {
+			&rules.BoardState{
+				Food:    []rules.Point{{X: 1, Y: 1}},
+				Hazards: []rules.Point{{X: 2, Y: 2}},
+				Snakes: []rules.Snake{
+					{
+						ID:   "1",
+						Body: []rules.Point{{X: 3, Y: 3}},
+					},
+				},
+			},
+			rules.Point{X: 2, Y: 3},
+			true, true, true,
+			false,
+		},
+		"food": {
+			&rules.BoardState{
+				Food: []rules.Point{{X: 1, Y: 1}},
+			},
+			rules.Point{X: 1, Y: 1},
+			false, false, true,
+			true,
+		},
+		"ignored food": {
+			&rules.BoardState{
+				Food: []rules.Point{{X: 1, Y: 1}},
+			},
+			rules.Point{X: 1, Y: 1},
+			false, false, false,
+			false,
+		},
+		"hazard": {
+			&rules.BoardState{
+				Hazards: []rules.Point{{X: 1, Y: 1}},
+			},
+			rules.Point{X: 1, Y: 1},
+			false, true, false,
+			true,
+		},
+		"ignored hazard": {
+			&rules.BoardState{
+				Food: []rules.Point{{X: 1, Y: 1}},
+			},
+			rules.Point{X: 1, Y: 1},
+			false, false, false,
+			false,
+		},
+		"snake": {
+			&rules.BoardState{
+				Snakes: []rules.Snake{
+					{
+						ID:   "1",
+						Body: []rules.Point{{X: 1, Y: 1}},
+					},
+				},
+			},
+			rules.Point{X: 1, Y: 1},
+			true, false, false,
+			true,
+		},
+		"ignored snake": {
+			&rules.BoardState{
+				Snakes: []rules.Snake{
+					{
+						ID:   "1",
+						Body: []rules.Point{{X: 1, Y: 1}},
+					},
+				},
+			},
+			rules.Point{X: 1, Y: 1},
+			false, false, false,
+			false,
+		},
+	} {
+		t.Run(label, func(t *testing.T) {
+			editor := NewBoardStateEditor(test.boardState)
+
+			actual := editor.IsOccupied(test.point, test.snakes, test.hazards, test.food)
+
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestBoardStateEditorOccupiedPoints(t *testing.T) {
+	testBoardState := &rules.BoardState{
+		Food:    []rules.Point{{X: 1, Y: 1}},
+		Hazards: []rules.Point{{X: 2, Y: 2}},
+		Snakes: []rules.Snake{
+			{
+				ID:   "1",
+				Body: []rules.Point{{X: 3, Y: 3}},
+			},
+		},
+	}
+
+	for label, test := range map[string]struct {
+		boardState            *rules.BoardState
+		snakes, hazards, food bool
+		expected              map[rules.Point]bool
+	}{
+		"empty board": {
+			rules.NewBoardState(rules.BoardSizeSmall, rules.BoardSizeSmall),
+			true, true, true,
+			map[rules.Point]bool{},
+		},
+		"all types": {
+			testBoardState,
+			true, true, true,
+			map[rules.Point]bool{
+				{X: 1, Y: 1}: true,
+				{X: 2, Y: 2}: true,
+				{X: 3, Y: 3}: true,
+			},
+		},
+		"ignore snakes": {
+			testBoardState,
+			false, true, true,
+			map[rules.Point]bool{
+				{X: 1, Y: 1}: true,
+				{X: 2, Y: 2}: true,
+			},
+		},
+		"ignore hazards": {
+			testBoardState,
+			true, false, true,
+			map[rules.Point]bool{
+				{X: 1, Y: 1}: true,
+				{X: 3, Y: 3}: true,
+			},
+		},
+		"ignore food": {
+			testBoardState,
+			true, true, false,
+			map[rules.Point]bool{
+				{X: 2, Y: 2}: true,
+				{X: 3, Y: 3}: true,
+			},
+		},
+	} {
+		t.Run(label, func(t *testing.T) {
+			editor := NewBoardStateEditor(test.boardState)
+
+			actual := editor.OccupiedPoints(test.snakes, test.hazards, test.food)
+
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestBoardStateEditorFilterUnoccupiedPoints(t *testing.T) {
+	testBoardState := &rules.BoardState{
+		Food:    []rules.Point{{X: 1, Y: 1}},
+		Hazards: []rules.Point{{X: 2, Y: 2}},
+		Snakes: []rules.Snake{
+			{
+				ID:   "1",
+				Body: []rules.Point{{X: 3, Y: 3}},
+			},
+		},
+	}
+
+	for label, test := range map[string]struct {
+		boardState            *rules.BoardState
+		targets               []rules.Point
+		snakes, hazards, food bool
+		expected              []rules.Point
+	}{
+		"empty": {
+			rules.NewBoardState(rules.BoardSizeSmall, rules.BoardSizeSmall),
+			[]rules.Point{},
+			true, true, true,
+			[]rules.Point{},
+		},
+		"all types": {
+			testBoardState,
+			[]rules.Point{{X: 3, Y: 3}, {X: 1, Y: 1}, {X: 2, Y: 2}, {X: 2, Y: 1}},
+			true, true, true,
+			[]rules.Point{{X: 2, Y: 1}},
+		},
+		"ignore snakes": {
+			testBoardState,
+			[]rules.Point{{X: 3, Y: 3}, {X: 1, Y: 1}, {X: 2, Y: 2}, {X: 2, Y: 1}},
+			false, true, true,
+			[]rules.Point{{X: 3, Y: 3}, {X: 2, Y: 1}},
+		},
+		"ignore hazards": {
+			testBoardState,
+			[]rules.Point{{X: 3, Y: 3}, {X: 1, Y: 1}, {X: 2, Y: 2}, {X: 2, Y: 1}},
+			true, false, true,
+			[]rules.Point{{X: 2, Y: 2}, {X: 2, Y: 1}},
+		},
+		"ignore food": {
+			testBoardState,
+			[]rules.Point{{X: 3, Y: 3}, {X: 1, Y: 1}, {X: 2, Y: 2}, {X: 2, Y: 1}},
+			true, true, false,
+			[]rules.Point{{X: 1, Y: 1}, {X: 2, Y: 1}},
+		},
+	} {
+		t.Run(label, func(t *testing.T) {
+			editor := NewBoardStateEditor(test.boardState)
+
+			actual := editor.FilterUnoccupiedPoints(test.targets, test.snakes, test.hazards, test.food)
+
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestBoardStateEditorShufflePoints(t *testing.T) {
+	editor := NewBoardStateEditor(rules.NewBoardState(rules.BoardSizeSmall, rules.BoardSizeSmall))
+	points := []rules.Point{{X: 4, Y: 0}, {X: 3, Y: 1}, {X: 2, Y: 2}, {X: 1, Y: 3}, {X: 0, Y: 4}}
+
+	editor.ShufflePoints(rules.MaxRand, points)
+	expected := []rules.Point{{X: 3, Y: 1}, {X: 2, Y: 2}, {X: 1, Y: 3}, {X: 0, Y: 4}, {X: 4, Y: 0}}
+
+	require.Equal(t, expected, points)
 }

--- a/maps/game_map_test.go
+++ b/maps/game_map_test.go
@@ -98,13 +98,13 @@ func TestMetadataValidate(t *testing.T) {
 
 func TestMapSizes(t *testing.T) {
 	s := FixedSizes(Dimensions{11, 12})
-	require.Equal(t, s[0].Width, uint(11))
-	require.Equal(t, s[0].Height, uint(12))
+	require.Equal(t, s[0].Width, 11)
+	require.Equal(t, s[0].Height, 12)
 
 	s = FixedSizes(Dimensions{11, 11}, Dimensions{19, 25})
 	require.Len(t, s, 2)
-	require.Equal(t, s[1].Width, uint(19))
-	require.Equal(t, s[1].Height, uint(25))
+	require.Equal(t, s[1].Width, 19)
+	require.Equal(t, s[1].Height, 25)
 
 	s = AnySize()
 	require.Len(t, s, 1, "unlimited maps should have just one dimensions")

--- a/maps/hazard_pits.go
+++ b/maps/hazard_pits.go
@@ -20,8 +20,8 @@ func (m HazardPitsMap) Meta() Metadata {
 		Description: "A map that that fills in grid-like pattern of squares with pits filled with hazard sauce. Every N turns the pits will fill with another layer of sauce up to a maximum of 4 layers which last a few cycles, then the pits drain and the pattern repeats",
 		Author:      "Battlesnake",
 		Version:     1,
-		MinPlayers:  1,
-		MaxPlayers:  4,
+		MinPlayers:  0,
+		MaxPlayers:  len(hazardPitStartPositions),
 		BoardSizes:  FixedSizes(Dimensions{11, 11}),
 		Tags:        []string{TAG_FOOD_PLACEMENT, TAG_HAZARD_PLACEMENT, TAG_SNAKE_PLACEMENT},
 	}
@@ -47,12 +47,8 @@ func (m HazardPitsMap) AddHazardPits(board *rules.BoardState, settings rules.Set
 }
 
 func (m HazardPitsMap) SetupBoard(initialBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-	if !m.Meta().BoardSizes.IsAllowable(initialBoardState.Width, initialBoardState.Height) {
-		return rules.RulesetError("This map can only be played on a 11x11 board")
-	}
-
-	if len(initialBoardState.Snakes) > len(hazardPitStartPositions) {
-		return rules.ErrorTooManySnakes
+	if err := m.Meta().Validate(initialBoardState); err != nil {
+		return err
 	}
 
 	rand := settings.GetRand(0)

--- a/maps/registry_test.go
+++ b/maps/registry_test.go
@@ -36,7 +36,7 @@ func TestRegisteredMaps(t *testing.T) {
 			for i := meta.MinPlayers; i < meta.MaxPlayers; i++ {
 				t.Run(fmt.Sprintf("%d players", i), func(t *testing.T) {
 					initialBoardState := rules.NewBoardState(int(mapSize.Width), int(mapSize.Height))
-					for j := uint(0); j < i; j++ {
+					for j := 0; j < i; j++ {
 						initialBoardState.Snakes = append(initialBoardState.Snakes, rules.Snake{ID: fmt.Sprint(j), Body: []rules.Point{}})
 					}
 					err := gameMap.SetupBoard(initialBoardState, testSettings, NewBoardStateEditor(initialBoardState))
@@ -49,7 +49,7 @@ func TestRegisteredMaps(t *testing.T) {
 				for _, mapSize := range meta.BoardSizes {
 					t.Run(fmt.Sprintf("%dx%d map size", mapSize.Width, mapSize.Height), func(t *testing.T) {
 						initialBoardState := rules.NewBoardState(int(mapSize.Width), int(mapSize.Height))
-						for i := uint(0); i < meta.MaxPlayers; i++ {
+						for i := 0; i < meta.MaxPlayers; i++ {
 							initialBoardState.Snakes = append(initialBoardState.Snakes, rules.Snake{ID: fmt.Sprint(i), Body: []rules.Point{}})
 						}
 						err := gameMap.SetupBoard(initialBoardState, testSettings, NewBoardStateEditor(initialBoardState))

--- a/maps/registry_test.go
+++ b/maps/registry_test.go
@@ -25,7 +25,6 @@ func TestRegisteredMaps(t *testing.T) {
 			require.Equalf(t, mapName, gameMap.ID(), "%#v game map doesn't return its own ID", mapName)
 			meta := gameMap.Meta()
 			require.True(t, meta.Version > 0, fmt.Sprintf("registered maps must have a valid version (>= 1) - '%d' is invalid", meta.Version))
-			require.NotZero(t, meta.MinPlayers, "registered maps must have minimum players declared")
 			require.NotZero(t, meta.MaxPlayers, "registered maps must have maximum players declared")
 			require.LessOrEqual(t, meta.MaxPlayers, meta.MaxPlayers, "max players should always be >= min players")
 			require.NotEmpty(t, meta.BoardSizes, "registered maps must have at least one supported size declared")

--- a/maps/rivers_and_bridges_test.go
+++ b/maps/rivers_and_bridges_test.go
@@ -21,8 +21,8 @@ func TestRiversAndBridgetsHazardsMap(t *testing.T) {
 
 	tests := []struct {
 		Map    maps.GameMap
-		Width  uint
-		Height uint
+		Width  int
+		Height int
 	}{
 		{maps.RiverAndBridgesMediumHazardsMap{}, 11, 11},
 		{maps.RiverAndBridgesLargeHazardsMap{}, 19, 19},
@@ -33,7 +33,7 @@ func TestRiversAndBridgetsHazardsMap(t *testing.T) {
 
 	// check all the supported sizes
 	for _, test := range tests {
-		state = rules.NewBoardState(int(test.Width), int(test.Height))
+		state = rules.NewBoardState(test.Width, test.Height)
 		state.Snakes = append(state.Snakes, rules.Snake{ID: "1", Body: []rules.Point{}})
 		editor = maps.NewBoardStateEditor(state)
 		require.Empty(t, state.Hazards)


### PR DESCRIPTION
Adds a Validate method to Metadata for checking and generating helpful errors when the number of players or map size is invalid, and a bunch of accessor methods to Editor for checking what's on the board already.

The refactoring of existing maps to use these will be in a follow-up ticket.