### PR TITLE
DEV-1703: Avoid spawning food on hazards for islands and bridges map

### DIFF
--- a/board.go
+++ b/board.go
@@ -189,11 +189,11 @@ func PlaceManySnakesDistributed(rand Rand, b *BoardState, snakeIDs []string) err
 	hOffset := quadHSpace / 3
 	vOffset := quadVSpace / 3
 
-	quads := make([]randomPositionBucket, 4)
+	quads := make([]RandomPositionBucket, 4)
 
 	// quad 1
-	quads[0] = randomPositionBucket{}
-	quads[0].fill(
+	quads[0] = RandomPositionBucket{}
+	quads[0].Fill(
 		Point{X: hOffset, Y: vOffset},
 		Point{X: quadHSpace - hOffset, Y: vOffset},
 		Point{X: hOffset, Y: quadVSpace - vOffset},
@@ -201,27 +201,27 @@ func PlaceManySnakesDistributed(rand Rand, b *BoardState, snakeIDs []string) err
 	)
 
 	// quad 2
-	quads[1] = randomPositionBucket{}
+	quads[1] = RandomPositionBucket{}
 	for _, p := range quads[0].positions {
-		quads[1].fill(Point{X: b.Width - p.X - 1, Y: p.Y})
+		quads[1].Fill(Point{X: b.Width - p.X - 1, Y: p.Y})
 	}
 
 	// quad 3
-	quads[2] = randomPositionBucket{}
+	quads[2] = RandomPositionBucket{}
 	for _, p := range quads[0].positions {
-		quads[2].fill(Point{X: p.X, Y: b.Height - p.Y - 1})
+		quads[2].Fill(Point{X: p.X, Y: b.Height - p.Y - 1})
 	}
 
 	// quad 4
-	quads[3] = randomPositionBucket{}
+	quads[3] = RandomPositionBucket{}
 	for _, p := range quads[0].positions {
-		quads[3].fill(Point{X: b.Width - p.X - 1, Y: b.Height - p.Y - 1})
+		quads[3].Fill(Point{X: b.Width - p.X - 1, Y: b.Height - p.Y - 1})
 	}
 
 	currentQuad := rand.Intn(4) // randomly pick a quadrant to start from
 	// evenly distribute snakes across quadrants, randomly, by rotating through the quadrants
 	for i := 0; i < len(b.Snakes); i++ {
-		p, err := quads[currentQuad].take(rand)
+		p, err := quads[currentQuad].Take(rand)
 		if err != nil {
 			return err
 		}
@@ -235,51 +235,15 @@ func PlaceManySnakesDistributed(rand Rand, b *BoardState, snakeIDs []string) err
 	return nil
 }
 
-func PlaceSnakesInQuadrants(rand Rand, b *BoardState, quadrants [][]Point) error {
-
-	if len(quadrants) != 4 {
-		return RulesetError("invalid start point configuration - not divided into quadrants")
-	}
-
-	// make sure all quadrants have the same number of positions
-	for i := 1; i < 4; i++ {
-		if len(quadrants[i]) != len(quadrants[0]) {
-			return RulesetError("invalid start point configuration - quadrants aren't even")
-		}
-	}
-
-	quads := make([]randomPositionBucket, 4)
-	for i := 0; i < 4; i++ {
-		quads[i].fill(quadrants[i]...)
-	}
-
-	currentQuad := rand.Intn(4) // randomly pick a quadrant to start from
-
-	// evenly distribute snakes across quadrants, randomly, by rotating through the quadrants
-	for i := 0; i < len(b.Snakes); i++ {
-		p, err := quads[currentQuad].take(rand)
-		if err != nil {
-			return err
-		}
-		for j := 0; j < SnakeStartSize; j++ {
-			b.Snakes[i].Body = append(b.Snakes[i].Body, p)
-		}
-
-		currentQuad = (currentQuad + 1) % 4
-	}
-
-	return nil
-}
-
-type randomPositionBucket struct {
+type RandomPositionBucket struct {
 	positions []Point
 }
 
-func (rpb *randomPositionBucket) fill(p ...Point) {
+func (rpb *RandomPositionBucket) Fill(p ...Point) {
 	rpb.positions = append(rpb.positions, p...)
 }
 
-func (rpb *randomPositionBucket) take(rand Rand) (Point, error) {
+func (rpb *RandomPositionBucket) Take(rand Rand) (Point, error) {
 	if len(rpb.positions) == 0 {
 		return Point{}, RulesetError("no more positions available")
 	}
@@ -359,6 +323,7 @@ func PlaceFoodAutomatically(rand Rand, b *BoardState) error {
 	return PlaceFoodRandomly(rand, b, len(b.Snakes))
 }
 
+// Deprecated: will be replaced by maps.PlaceFoodFixed
 func PlaceFoodFixed(rand Rand, b *BoardState) error {
 	centerCoord := Point{(b.Width - 1) / 2, (b.Height - 1) / 2}
 

--- a/maps/helpers_test.go
+++ b/maps/helpers_test.go
@@ -115,3 +115,33 @@ func TestUpdateBoard(t *testing.T) {
 		require.Equal(t, []rules.Point{{X: 3, Y: 4}, {X: 3, Y: 5}, {X: 2, Y: 2}}, boardState.Hazards)
 	})
 }
+
+func TestPlaceFoodFixed(t *testing.T) {
+	initialBoardState := rules.NewBoardState(rules.BoardSizeMedium, rules.BoardSizeMedium)
+	editor := maps.NewBoardStateEditor(initialBoardState.Clone())
+
+	editor.PlaceSnake("1", []rules.Point{{X: 1, Y: 1}}, 100)
+	editor.PlaceSnake("2", []rules.Point{{X: 9, Y: 1}}, 100)
+	editor.PlaceSnake("3", []rules.Point{{X: 4, Y: 9}}, 100)
+	editor.PlaceSnake("4", []rules.Point{{X: 6, Y: 6}}, 100)
+
+	// Hazards everywhere except for the expected food placements
+	for x := 0; x < initialBoardState.Width; x++ {
+		for y := 0; y < initialBoardState.Height; y++ {
+			editor.AddHazard(rules.Point{X: x, Y: y})
+		}
+	}
+	editor.RemoveHazard(rules.Point{X: 0, Y: 2})
+	editor.RemoveHazard(rules.Point{X: 8, Y: 0})
+	editor.RemoveHazard(rules.Point{X: 3, Y: 10})
+	editor.RemoveHazard(rules.Point{X: 7, Y: 7})
+
+	err := maps.PlaceFoodFixed(rules.MaxRand, initialBoardState, editor)
+	require.NoError(t, err)
+
+	food := editor.Food()
+	require.Contains(t, food, rules.Point{X: 0, Y: 2})
+	require.Contains(t, food, rules.Point{X: 8, Y: 0})
+	require.Contains(t, food, rules.Point{X: 3, Y: 10})
+	require.Contains(t, food, rules.Point{X: 7, Y: 7})
+}

--- a/maps/rivers_and_bridges_test.go
+++ b/maps/rivers_and_bridges_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRiversAndBridgetsHazardsMap(t *testing.T) {
+func TestRiversAndBridgesHazardsMap(t *testing.T) {
 	// check error handling
 	m := maps.RiverAndBridgesMediumHazardsMap{}
 	settings := rules.Settings{}
@@ -40,5 +40,8 @@ func TestRiversAndBridgetsHazardsMap(t *testing.T) {
 		err = test.Map.SetupBoard(state, settings, editor)
 		require.NoError(t, err)
 		require.NotEmpty(t, state.Hazards)
+		require.Len(t, state.Food, 1)
+		food := state.Food[0]
+		require.NotContains(t, state.Hazards, food)
 	}
 }


### PR DESCRIPTION
Also refactors these maps to avoid using a temp board state, and moves a few utilities from the top-level package into maps.