### PR TITLE
DEV-1761: Clean up Ruleset interface

### DIFF
--- a/cases_test.go
+++ b/cases_test.go
@@ -29,8 +29,8 @@ func (gc *gameTestCase) requireValidNextState(t *testing.T, r Ruleset) {
 	t.Helper()
 	t.Run(gc.name, func(t *testing.T) {
 		t.Helper()
-		prev := gc.prevState.Clone() // clone to protect against mutation (so we can ru-use test cases)
-		nextState, err := r.CreateNextBoardState(prev, gc.moves)
+		prev := gc.prevState.Clone() // clone to protect against mutation (so we can re-use test cases)
+		_, nextState, err := r.Execute(prev, r.Settings(), gc.moves)
 		require.Equal(t, gc.expectedError, err)
 		if gc.expectedState != nil {
 			require.Equal(t, gc.expectedState.Width, nextState.Width)

--- a/cases_test.go
+++ b/cases_test.go
@@ -30,7 +30,7 @@ func (gc *gameTestCase) requireValidNextState(t *testing.T, r Ruleset) {
 	t.Run(gc.name, func(t *testing.T) {
 		t.Helper()
 		prev := gc.prevState.Clone() // clone to protect against mutation (so we can re-use test cases)
-		_, nextState, err := r.Execute(prev, r.Settings(), gc.moves)
+		_, nextState, err := r.Execute(prev, gc.moves)
 		require.Equal(t, gc.expectedError, err)
 		if gc.expectedState != nil {
 			require.Equal(t, gc.expectedState.Width, nextState.Width)

--- a/cli/commands/play.go
+++ b/cli/commands/play.go
@@ -354,7 +354,7 @@ func (gameState *GameState) initializeBoardFromArgs() (bool, *rules.BoardState, 
 	if err != nil {
 		return false, nil, fmt.Errorf("Error initializing BoardState with map: %w", err)
 	}
-	gameOver, boardState, err := gameState.ruleset.Execute(boardState, gameState.ruleset.Settings(), nil)
+	gameOver, boardState, err := gameState.ruleset.Execute(boardState, nil)
 	if err != nil {
 		return false, nil, fmt.Errorf("Error initializing BoardState with ruleset: %w", err)
 	}
@@ -412,7 +412,7 @@ func (gameState *GameState) createNextBoardState(boardState *rules.BoardState) (
 		moves = append(moves, rules.SnakeMove{ID: snakeState.ID, Move: snakeState.LastMove})
 	}
 
-	gameOver, boardState, err := gameState.ruleset.Execute(boardState, gameState.ruleset.Settings(), moves)
+	gameOver, boardState, err := gameState.ruleset.Execute(boardState, moves)
 	if err != nil {
 		return false, boardState, fmt.Errorf("Error producing next board state: %w", err)
 	}

--- a/cli/commands/play.go
+++ b/cli/commands/play.go
@@ -541,7 +541,7 @@ func (gameState *GameState) createClientGame() client.Game {
 		Ruleset: client.Ruleset{
 			Name:     gameState.ruleset.Name(),
 			Version:  "cli", // TODO: Use GitHub Release Version
-			Settings: gameState.ruleset.Settings(),
+			Settings: client.ConvertRulesetSettings(gameState.ruleset.Settings()),
 		},
 		Map: gameState.gameMap.ID(),
 	}

--- a/cli/commands/play_test.go
+++ b/cli/commands/play_test.go
@@ -631,7 +631,7 @@ type StubRuleset struct {
 
 func (ruleset StubRuleset) Name() string             { return "standard" }
 func (ruleset StubRuleset) Settings() rules.Settings { return ruleset.settings }
-func (ruleset StubRuleset) Execute(prevState *rules.BoardState, settings rules.Settings, moves []rules.SnakeMove) (bool, *rules.BoardState, error) {
+func (ruleset StubRuleset) Execute(prevState *rules.BoardState, moves []rules.SnakeMove) (bool, *rules.BoardState, error) {
 	return prevState.Turn >= ruleset.maxTurns, prevState, nil
 }
 

--- a/cli/commands/play_test.go
+++ b/cli/commands/play_test.go
@@ -549,7 +549,9 @@ func TestCreateNextBoardState(t *testing.T) {
 			gameState.snakeStates = map[string]SnakeState{s1.ID: snakeState}
 			gameState.httpClient = stubHTTPClient{nil, 200, func(_ string) string { return `{"move": "right"}` }, 54 * time.Millisecond}
 
-			nextBoardState := gameState.createNextBoardState(boardState)
+			gameOver, nextBoardState, err := gameState.createNextBoardState(boardState)
+			require.NoError(t, err)
+			require.False(t, gameOver)
 			snakeState = gameState.snakeStates[s1.ID]
 
 			require.NotNil(t, nextBoardState)
@@ -593,16 +595,19 @@ func TestOutputFile(t *testing.T) {
 	outputFile := new(closableBuffer)
 	gameState.outputFile = outputFile
 
-	gameState.ruleset = StubRuleset{maxTurns: 1, settings: rules.Settings{
-		FoodSpawnChance:     1,
-		MinimumFood:         2,
-		HazardDamagePerTurn: 3,
-		RoyaleSettings: rules.RoyaleSettings{
-			ShrinkEveryNTurns: 4,
-		},
-	}}
+	gameState.ruleset = StubRuleset{
+		maxTurns: 1,
+		settings: rules.Settings{
+			FoodSpawnChance:     1,
+			MinimumFood:         2,
+			HazardDamagePerTurn: 3,
+			RoyaleSettings: rules.RoyaleSettings{
+				ShrinkEveryNTurns: 4,
+			},
+		}}
 
-	gameState.Run()
+	err = gameState.Run()
+	require.NoError(t, err)
 
 	lines := strings.Split(outputFile.String(), "\n")
 	require.Len(t, lines, 5)
@@ -626,14 +631,8 @@ type StubRuleset struct {
 
 func (ruleset StubRuleset) Name() string             { return "standard" }
 func (ruleset StubRuleset) Settings() rules.Settings { return ruleset.settings }
-func (ruleset StubRuleset) ModifyInitialBoardState(initialState *rules.BoardState) (*rules.BoardState, error) {
-	return initialState, nil
-}
-func (ruleset StubRuleset) CreateNextBoardState(prevState *rules.BoardState, moves []rules.SnakeMove) (*rules.BoardState, error) {
-	return prevState, nil
-}
-func (ruleset StubRuleset) IsGameOver(state *rules.BoardState) (bool, error) {
-	return state.Turn >= ruleset.maxTurns, nil
+func (ruleset StubRuleset) Execute(prevState *rules.BoardState, settings rules.Settings, moves []rules.SnakeMove) (bool, *rules.BoardState, error) {
+	return prevState.Turn >= ruleset.maxTurns, prevState, nil
 }
 
 type stubHTTPClient struct {

--- a/cli/commands/play_test.go
+++ b/cli/commands/play_test.go
@@ -597,14 +597,13 @@ func TestOutputFile(t *testing.T) {
 
 	gameState.ruleset = StubRuleset{
 		maxTurns: 1,
-		settings: rules.Settings{
-			FoodSpawnChance:     1,
-			MinimumFood:         2,
-			HazardDamagePerTurn: 3,
-			RoyaleSettings: rules.RoyaleSettings{
-				ShrinkEveryNTurns: 4,
-			},
-		}}
+		settings: rules.NewSettings(map[string]string{
+			rules.ParamFoodSpawnChance:     "1",
+			rules.ParamMinimumFood:         "2",
+			rules.ParamHazardDamagePerTurn: "3",
+			rules.ParamShrinkEveryNTurns:   "4",
+		}),
+	}
 
 	err = gameState.Run()
 	require.NoError(t, err)

--- a/client/fixtures_test.go
+++ b/client/fixtures_test.go
@@ -9,7 +9,7 @@ func exampleSnakeRequest() SnakeRequest {
 			Ruleset: Ruleset{
 				Name:     "test-ruleset-name",
 				Version:  "cli",
-				Settings: exampleRulesetSettings,
+				Settings: ConvertRulesetSettings(exampleRulesetSettings),
 			},
 			Timeout: 33,
 			Source:  "league",
@@ -75,21 +75,9 @@ func exampleSnakeRequest() SnakeRequest {
 	}
 }
 
-var exampleRulesetSettings = rules.Settings{
-	FoodSpawnChance:     10,
-	MinimumFood:         20,
-	HazardDamagePerTurn: 30,
-	HazardMap:           "hz_spiral",
-	HazardMapAuthor:     "altersaddle",
-
-	RoyaleSettings: rules.RoyaleSettings{
-		ShrinkEveryNTurns: 40,
-	},
-
-	SquadSettings: rules.SquadSettings{
-		AllowBodyCollisions: true,
-		SharedElimination:   true,
-		SharedHealth:        true,
-		SharedLength:        true,
-	},
-}
+var exampleRulesetSettings = rules.NewSettings(map[string]string{
+	rules.ParamFoodSpawnChance:     "10",
+	rules.ParamMinimumFood:         "20",
+	rules.ParamHazardDamagePerTurn: "30",
+	rules.ParamShrinkEveryNTurns:   "40",
+})

--- a/client/models.go
+++ b/client/models.go
@@ -49,19 +49,47 @@ type Customizations struct {
 }
 
 type Ruleset struct {
-	Name     string         `json:"name"`
-	Version  string         `json:"version"`
-	Settings rules.Settings `json:"settings"`
+	Name     string          `json:"name"`
+	Version  string          `json:"version"`
+	Settings RulesetSettings `json:"settings"`
 }
 
-// RulesetSettings is deprecated: use rules.Settings instead
-type RulesetSettings rules.Settings
+// RulesetSettings contains a static collection of a few settings that are exposed through the API.
+type RulesetSettings struct {
+	FoodSpawnChance     int            `json:"foodSpawnChance"`
+	MinimumFood         int            `json:"minimumFood"`
+	HazardDamagePerTurn int            `json:"hazardDamagePerTurn"`
+	HazardMap           string         `json:"hazardMap"`       // Deprecated, replaced by Game.Map
+	HazardMapAuthor     string         `json:"hazardMapAuthor"` // Deprecated, no planned replacement
+	RoyaleSettings      RoyaleSettings `json:"royale"`
+	SquadSettings       SquadSettings  `json:"squad"` // Deprecated, provided with default fields for API compatibility
+}
 
-// RoyaleSettings is deprecated: use rules.RoyaleSettings instead
-type RoyaleSettings rules.RoyaleSettings
+// RoyaleSettings contains settings that are specific to the "royale" game mode
+type RoyaleSettings struct {
+	ShrinkEveryNTurns int `json:"shrinkEveryNTurns"`
+}
 
-// SquadSettings is deprecated: use rules.SquadSettings instead
-type SquadSettings rules.SquadSettings
+// SquadSettings contains settings that are specific to the "squad" game mode
+type SquadSettings struct {
+	AllowBodyCollisions bool `json:"allowBodyCollisions"`
+	SharedElimination   bool `json:"sharedElimination"`
+	SharedHealth        bool `json:"sharedHealth"`
+	SharedLength        bool `json:"sharedLength"`
+}
+
+// Converts a rules.Settings (which can contain arbitrary settings) into the static RulesetSettings used in the client API.
+func ConvertRulesetSettings(settings rules.Settings) RulesetSettings {
+	return RulesetSettings{
+		FoodSpawnChance:     settings.Int(rules.ParamFoodSpawnChance, 0),
+		MinimumFood:         settings.Int(rules.ParamMinimumFood, 0),
+		HazardDamagePerTurn: settings.Int(rules.ParamHazardDamagePerTurn, 0),
+		RoyaleSettings: RoyaleSettings{
+			ShrinkEveryNTurns: settings.Int(rules.ParamShrinkEveryNTurns, 0),
+		},
+		SquadSettings: SquadSettings{},
+	}
+}
 
 // Coord represents a point on the board
 type Coord struct {

--- a/client/models_test.go
+++ b/client/models_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/BattlesnakeOfficial/rules"
 	"github.com/BattlesnakeOfficial/rules/test"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +18,7 @@ func TestBuildSnakeRequestJSON(t *testing.T) {
 
 func TestBuildSnakeRequestJSONEmptyRulesetSettings(t *testing.T) {
 	snakeRequest := exampleSnakeRequest()
-	snakeRequest.Game.Ruleset.Settings = rules.Settings{}
+	snakeRequest.Game.Ruleset.Settings = RulesetSettings{}
 	data, err := json.MarshalIndent(snakeRequest, "", "  ")
 	require.NoError(t, err)
 

--- a/client/testdata/snake_request.json
+++ b/client/testdata/snake_request.json
@@ -8,16 +8,16 @@
         "foodSpawnChance": 10,
         "minimumFood": 20,
         "hazardDamagePerTurn": 30,
-        "hazardMap": "hz_spiral",
-        "hazardMapAuthor": "altersaddle",
+        "hazardMap": "",
+        "hazardMapAuthor": "",
         "royale": {
           "shrinkEveryNTurns": 40
         },
         "squad": {
-          "allowBodyCollisions": true,
-          "sharedElimination": true,
-          "sharedHealth": true,
-          "sharedLength": true
+          "allowBodyCollisions": false,
+          "sharedElimination": false,
+          "sharedHealth": false,
+          "sharedLength": false
         }
       }
     },

--- a/constrictor.go
+++ b/constrictor.go
@@ -22,31 +22,6 @@ var wrappedConstrictorRulesetStages = []string{
 	StageModifySnakesAlwaysGrow,
 }
 
-type ConstrictorRuleset struct {
-	StandardRuleset
-}
-
-func (r *ConstrictorRuleset) Name() string { return GameTypeConstrictor }
-
-func (r ConstrictorRuleset) Execute(bs *BoardState, s Settings, sm []SnakeMove) (bool, *BoardState, error) {
-	return NewPipeline(constrictorRulesetStages...).Execute(bs, s, sm)
-}
-
-func (r *ConstrictorRuleset) ModifyInitialBoardState(initialBoardState *BoardState) (*BoardState, error) {
-	_, nextState, err := r.Execute(initialBoardState, r.Settings(), nil)
-	return nextState, err
-}
-
-func (r *ConstrictorRuleset) CreateNextBoardState(prevState *BoardState, moves []SnakeMove) (*BoardState, error) {
-	_, nextState, err := r.Execute(prevState, r.Settings(), moves)
-
-	return nextState, err
-}
-
-func (r *ConstrictorRuleset) IsGameOver(b *BoardState) (bool, error) {
-	return GameOverStandard(b, r.Settings(), nil)
-}
-
 func RemoveFoodConstrictor(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
 	// Remove all food from the board
 	b.Food = []Point{}

--- a/constrictor_test.go
+++ b/constrictor_test.go
@@ -4,10 +4,6 @@ import (
 	"testing"
 )
 
-func TestConstrictorRulesetInterface(t *testing.T) {
-	var _ Ruleset = (*ConstrictorRuleset)(nil)
-}
-
 // Test that two equal snakes collide and both get eliminated
 // also checks:
 //	- food removed
@@ -70,15 +66,11 @@ func TestConstrictorCreateNextBoardState(t *testing.T) {
 		standardCaseErrZeroLengthSnake,
 		constrictorMoveAndCollideMAD,
 	}
-	rb := NewRulesetBuilder().WithParams(map[string]string{
-		ParamGameType: GameTypeConstrictor,
-	})
-	r := ConstrictorRuleset{}
+	r := NewRulesetBuilder().NamedRuleset(GameTypeConstrictor)
 	for _, gc := range cases {
-		gc.requireValidNextState(t, &r)
-		// also test a RulesBuilder constructed instance
-		gc.requireValidNextState(t, rb.Ruleset())
+		// test a RulesBuilder constructed instance
+		gc.requireValidNextState(t, r)
 		// also test a pipeline with the same settings
-		gc.requireValidNextState(t, rb.PipelineRuleset(GameTypeConstrictor, NewPipeline(constrictorRulesetStages...)))
+		gc.requireValidNextState(t, NewRulesetBuilder().PipelineRuleset(GameTypeConstrictor, NewPipeline(constrictorRulesetStages...)))
 	}
 }

--- a/maps/arcade_maze.go
+++ b/maps/arcade_maze.go
@@ -63,7 +63,7 @@ func (m ArcadeMazeMap) SetupBoard(initialBoardState *rules.BoardState, settings 
 		editor.AddHazard(hazard)
 	}
 
-	if settings.MinimumFood > 0 {
+	if settings.Int(rules.ParamMinimumFood, 0) > 0 {
 		// Add food in center
 		editor.AddFood(rules.Point{X: 9, Y: 11})
 	}
@@ -75,7 +75,8 @@ func (m ArcadeMazeMap) UpdateBoard(lastBoardState *rules.BoardState, settings ru
 	rand := settings.GetRand(lastBoardState.Turn)
 
 	// Respect FoodSpawnChance setting
-	if settings.FoodSpawnChance == 0 || rand.Intn(100) > settings.FoodSpawnChance {
+	foodSpawnChance := settings.Int(rules.ParamFoodSpawnChance, 0)
+	if foodSpawnChance == 0 || rand.Intn(100) > foodSpawnChance {
 		return nil
 	}
 

--- a/maps/empty_test.go
+++ b/maps/empty_test.go
@@ -146,10 +146,7 @@ func TestEmptyMapUpdateBoard(t *testing.T) {
 		Food:    []rules.Point{{X: 0, Y: 0}},
 		Hazards: []rules.Point{},
 	}
-	settings := rules.Settings{
-		FoodSpawnChance: 50,
-		MinimumFood:     2,
-	}.WithRand(rules.MaxRand)
+	settings := rules.NewSettingsWithParams(rules.ParamFoodSpawnChance, "50", rules.ParamMinimumFood, "2").WithRand(rules.MaxRand)
 	nextBoardState := initialBoardState.Clone()
 
 	err := m.UpdateBoard(initialBoardState.Clone(), settings, maps.NewBoardStateEditor(nextBoardState))

--- a/maps/hazard_pits.go
+++ b/maps/hazard_pits.go
@@ -109,9 +109,10 @@ func (m HazardPitsMap) UpdateBoard(lastBoardState *rules.BoardState, settings ru
 	// Cycle 3 - 3 layers
 	// Cycle 4-6 - 4 layers of hazards
 
-	if lastBoardState.Turn%settings.RoyaleSettings.ShrinkEveryNTurns == 0 {
+	shrinkEveryNTurns := settings.Int(rules.ParamShrinkEveryNTurns, 0)
+	if lastBoardState.Turn%shrinkEveryNTurns == 0 {
 		// Is it time to update the hazards
-		layers := (lastBoardState.Turn / settings.RoyaleSettings.ShrinkEveryNTurns) % 7
+		layers := (lastBoardState.Turn / shrinkEveryNTurns) % 7
 		if layers > 4 {
 			layers = 4
 		}

--- a/maps/hazard_pits_test.go
+++ b/maps/hazard_pits_test.go
@@ -38,7 +38,7 @@ func TestHazardPitsMap(t *testing.T) {
 
 	state = rules.NewBoardState(int(11), int(11))
 	m = maps.HazardPitsMap{}
-	settings.RoyaleSettings.ShrinkEveryNTurns = 1
+	settings = rules.NewSettingsWithParams(rules.ParamShrinkEveryNTurns, "1")
 	editor = maps.NewBoardStateEditor(state)
 	require.Empty(t, state.Hazards)
 	err = m.SetupBoard(state, settings, editor)

--- a/maps/healing_pools.go
+++ b/maps/healing_pools.go
@@ -55,7 +55,8 @@ func (m HealingPoolsMap) UpdateBoard(lastBoardState *rules.BoardState, settings 
 		return err
 	}
 
-	if lastBoardState.Turn > 0 && settings.RoyaleSettings.ShrinkEveryNTurns > 0 && len(lastBoardState.Hazards) > 0 && lastBoardState.Turn%settings.RoyaleSettings.ShrinkEveryNTurns == 0 {
+	shrinkEveryNTurns := settings.Int(rules.ParamShrinkEveryNTurns, 0)
+	if lastBoardState.Turn > 0 && shrinkEveryNTurns > 0 && len(lastBoardState.Hazards) > 0 && lastBoardState.Turn%shrinkEveryNTurns == 0 {
 		// Attempt to remove a healing pool every ShrinkEveryNTurns until there are none remaining
 		i := rand.Intn(len(lastBoardState.Hazards))
 		editor.RemoveHazard(lastBoardState.Hazards[i])

--- a/maps/healing_pools_test.go
+++ b/maps/healing_pools_test.go
@@ -40,8 +40,8 @@ func TestHealingPoolsMap(t *testing.T) {
 		t.Run(fmt.Sprintf("%dx%d", tc.boardSize, tc.boardSize), func(t *testing.T) {
 			m := maps.HealingPoolsMap{}
 			state := rules.NewBoardState(tc.boardSize, tc.boardSize)
-			settings := rules.Settings{}
-			settings.RoyaleSettings.ShrinkEveryNTurns = 10
+			shrinkEveryNTurns := 10
+			settings := rules.NewSettingsWithParams(rules.ParamShrinkEveryNTurns, fmt.Sprint(shrinkEveryNTurns))
 
 			// ensure the hazards are added to the board at setup
 			editor := maps.NewBoardStateEditor(state)
@@ -56,7 +56,7 @@ func TestHealingPoolsMap(t *testing.T) {
 			}
 
 			// ensure the hazards are removed
-			totalTurns := settings.RoyaleSettings.ShrinkEveryNTurns*tc.expectedHazards + 1
+			totalTurns := shrinkEveryNTurns*tc.expectedHazards + 1
 			for i := 0; i < totalTurns; i++ {
 				state.Turn = i
 				err = m.UpdateBoard(state, settings, editor)

--- a/maps/registry_test.go
+++ b/maps/registry_test.go
@@ -10,14 +10,12 @@ import (
 
 const maxBoardWidth, maxBoardHeight = 25, 25
 
-var testSettings rules.Settings = rules.Settings{
-	FoodSpawnChance:     25,
-	MinimumFood:         1,
-	HazardDamagePerTurn: 14,
-	RoyaleSettings: rules.RoyaleSettings{
-		ShrinkEveryNTurns: 1,
-	},
-}
+var testSettings rules.Settings = rules.NewSettings(map[string]string{
+	rules.ParamFoodSpawnChance:     "25",
+	rules.ParamMinimumFood:         "1",
+	rules.ParamHazardDamagePerTurn: "14",
+	rules.ParamShrinkEveryNTurns:   "1",
+})
 
 func TestRegisteredMaps(t *testing.T) {
 	for mapName, gameMap := range globalRegistry {

--- a/maps/royale.go
+++ b/maps/royale.go
@@ -42,11 +42,12 @@ func (m RoyaleHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings
 	// Royale uses the current turn to generate hazards, not the previous turn that's in the board state
 	turn := lastBoardState.Turn + 1
 
-	if settings.RoyaleSettings.ShrinkEveryNTurns < 1 {
+	shrinkEveryNTurns := settings.Int(rules.ParamShrinkEveryNTurns, 0)
+	if shrinkEveryNTurns < 1 {
 		return errors.New("royale game can't shrink more frequently than every turn")
 	}
 
-	if turn < settings.RoyaleSettings.ShrinkEveryNTurns {
+	if turn < shrinkEveryNTurns {
 		return nil
 	}
 
@@ -56,7 +57,7 @@ func (m RoyaleHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings
 	// Get random generator for turn zero, because we're regenerating all hazards every time.
 	randGenerator := settings.GetRand(0)
 
-	numShrinks := turn / settings.RoyaleSettings.ShrinkEveryNTurns
+	numShrinks := turn / shrinkEveryNTurns
 	minX, maxX := 0, lastBoardState.Width-1
 	minY, maxY := 0, lastBoardState.Height-1
 	for i := 0; i < numShrinks; i++ {

--- a/maps/sinkholes.go
+++ b/maps/sinkholes.go
@@ -42,8 +42,9 @@ func (m SinkholesMap) UpdateBoard(lastBoardState *rules.BoardState, settings rul
 	currentTurn := lastBoardState.Turn
 	startTurn := 1
 	spawnEveryNTurns := 10
-	if settings.RoyaleSettings.ShrinkEveryNTurns > 0 {
-		spawnEveryNTurns = settings.RoyaleSettings.ShrinkEveryNTurns
+	shrinkEveryNTurns := settings.Int(rules.ParamShrinkEveryNTurns, 0)
+	if shrinkEveryNTurns > 0 {
+		spawnEveryNTurns = shrinkEveryNTurns
 	}
 	maxRings := 5
 	if lastBoardState.Width == 7 {

--- a/maps/standard.go
+++ b/maps/standard.go
@@ -69,8 +69,8 @@ func (m StandardMap) UpdateBoard(lastBoardState *rules.BoardState, settings rule
 }
 
 func checkFoodNeedingPlacement(rand rules.Rand, settings rules.Settings, state *rules.BoardState) int {
-	minFood := int(settings.MinimumFood)
-	foodSpawnChance := int(settings.FoodSpawnChance)
+	minFood := settings.Int(rules.ParamMinimumFood, 0)
+	foodSpawnChance := settings.Int(rules.ParamFoodSpawnChance, 0)
 	numCurrentFood := len(state.Food)
 
 	if numCurrentFood < minFood {

--- a/maps/standard_test.go
+++ b/maps/standard_test.go
@@ -172,10 +172,7 @@ func TestStandardMapUpdateBoard(t *testing.T) {
 		{
 			"empty no food",
 			rules.NewBoardState(2, 2),
-			rules.Settings{
-				FoodSpawnChance: 0,
-				MinimumFood:     0,
-			},
+			rules.NewSettingsWithParams(rules.ParamFoodSpawnChance, "0", rules.ParamMinimumFood, "0"),
 			rules.MinRand,
 			&rules.BoardState{
 				Width:   2,
@@ -188,10 +185,7 @@ func TestStandardMapUpdateBoard(t *testing.T) {
 		{
 			"empty MinimumFood",
 			rules.NewBoardState(2, 2),
-			rules.Settings{
-				FoodSpawnChance: 0,
-				MinimumFood:     2,
-			},
+			rules.NewSettingsWithParams(rules.ParamFoodSpawnChance, "0", rules.ParamMinimumFood, "2"),
 			rules.MinRand,
 			&rules.BoardState{
 				Width:   2,
@@ -210,10 +204,7 @@ func TestStandardMapUpdateBoard(t *testing.T) {
 				Food:    []rules.Point{{X: 0, Y: 1}},
 				Hazards: []rules.Point{},
 			},
-			rules.Settings{
-				FoodSpawnChance: 0,
-				MinimumFood:     2,
-			},
+			rules.NewSettingsWithParams(rules.ParamFoodSpawnChance, "0", rules.ParamMinimumFood, "2"),
 			rules.MinRand,
 			&rules.BoardState{
 				Width:   2,
@@ -226,10 +217,7 @@ func TestStandardMapUpdateBoard(t *testing.T) {
 		{
 			"empty FoodSpawnChance inactive",
 			rules.NewBoardState(2, 2),
-			rules.Settings{
-				FoodSpawnChance: 50,
-				MinimumFood:     0,
-			},
+			rules.NewSettingsWithParams(rules.ParamFoodSpawnChance, "50", rules.ParamMinimumFood, "0"),
 			rules.MinRand,
 			&rules.BoardState{
 				Width:   2,
@@ -242,10 +230,7 @@ func TestStandardMapUpdateBoard(t *testing.T) {
 		{
 			"empty FoodSpawnChance active",
 			rules.NewBoardState(2, 2),
-			rules.Settings{
-				FoodSpawnChance: 50,
-				MinimumFood:     0,
-			},
+			rules.NewSettingsWithParams(rules.ParamFoodSpawnChance, "50", rules.ParamMinimumFood, "0"),
 			rules.MaxRand,
 			&rules.BoardState{
 				Width:   2,
@@ -264,10 +249,7 @@ func TestStandardMapUpdateBoard(t *testing.T) {
 				Food:    []rules.Point{{X: 0, Y: 0}},
 				Hazards: []rules.Point{},
 			},
-			rules.Settings{
-				FoodSpawnChance: 50,
-				MinimumFood:     0,
-			},
+			rules.NewSettingsWithParams(rules.ParamFoodSpawnChance, "50", rules.ParamMinimumFood, "0"),
 			rules.MaxRand,
 			&rules.BoardState{
 				Width:   2,
@@ -286,10 +268,7 @@ func TestStandardMapUpdateBoard(t *testing.T) {
 				Food:    []rules.Point{{X: 0, Y: 0}, {X: 0, Y: 1}, {X: 1, Y: 0}, {X: 1, Y: 1}},
 				Hazards: []rules.Point{},
 			},
-			rules.Settings{
-				FoodSpawnChance: 50,
-				MinimumFood:     0,
-			},
+			rules.NewSettingsWithParams(rules.ParamFoodSpawnChance, "50", rules.ParamMinimumFood, "0"),
 			rules.MaxRand,
 			&rules.BoardState{
 				Width:   2,

--- a/pipeline_internal_test.go
+++ b/pipeline_internal_test.go
@@ -27,7 +27,7 @@ func TestPipelineRuleset(t *testing.T) {
 		name:     "test",
 		pipeline: p,
 	}
-	ended, err := pr.IsGameOver(&BoardState{})
+	ended, _, err := pr.Execute(&BoardState{}, pr.Settings(), nil)
 	require.NoError(t, err)
 	require.True(t, ended)
 
@@ -37,7 +37,7 @@ func TestPipelineRuleset(t *testing.T) {
 		name:     "test",
 		pipeline: p,
 	}
-	ended, err = pr.IsGameOver(&BoardState{})
+	ended, _, err = pr.Execute(&BoardState{}, pr.Settings(), nil)
 	require.NoError(t, err)
 	require.False(t, ended)
 
@@ -56,10 +56,10 @@ func TestPipelineRuleset(t *testing.T) {
 		pipeline: p,
 	}
 	require.Empty(t, b.Food)
-	b, err = pr.ModifyInitialBoardState(b)
+	_, b, err = pr.Execute(b, pr.Settings(), nil)
 	require.NoError(t, err)
 	require.Empty(t, b.Food, "food should not be added on initialisation phase")
-	b, err = pr.CreateNextBoardState(b, mockSnakeMoves())
+	_, b, err = pr.Execute(b, pr.Settings(), mockSnakeMoves())
 	require.NoError(t, err)
 	require.NotEmpty(t, b.Food, "fodo should be added now")
 }

--- a/pipeline_internal_test.go
+++ b/pipeline_internal_test.go
@@ -27,7 +27,7 @@ func TestPipelineRuleset(t *testing.T) {
 		name:     "test",
 		pipeline: p,
 	}
-	ended, _, err := pr.Execute(&BoardState{}, pr.Settings(), nil)
+	ended, _, err := pr.Execute(&BoardState{}, nil)
 	require.NoError(t, err)
 	require.True(t, ended)
 
@@ -37,7 +37,7 @@ func TestPipelineRuleset(t *testing.T) {
 		name:     "test",
 		pipeline: p,
 	}
-	ended, _, err = pr.Execute(&BoardState{}, pr.Settings(), nil)
+	ended, _, err = pr.Execute(&BoardState{}, nil)
 	require.NoError(t, err)
 	require.False(t, ended)
 
@@ -56,10 +56,10 @@ func TestPipelineRuleset(t *testing.T) {
 		pipeline: p,
 	}
 	require.Empty(t, b.Food)
-	_, b, err = pr.Execute(b, pr.Settings(), nil)
+	_, b, err = pr.Execute(b, nil)
 	require.NoError(t, err)
 	require.Empty(t, b.Food, "food should not be added on initialisation phase")
-	_, b, err = pr.Execute(b, pr.Settings(), mockSnakeMoves())
+	_, b, err = pr.Execute(b, mockSnakeMoves())
 	require.NoError(t, err)
 	require.NotEmpty(t, b.Food, "fodo should be added now")
 }

--- a/royale.go
+++ b/royale.go
@@ -14,26 +14,6 @@ var royaleRulesetStages = []string{
 	StageSpawnHazardsShrinkMap,
 }
 
-type RoyaleRuleset struct {
-	StandardRuleset
-
-	ShrinkEveryNTurns int
-}
-
-func (r *RoyaleRuleset) Name() string { return GameTypeRoyale }
-
-func (r RoyaleRuleset) Execute(bs *BoardState, s Settings, sm []SnakeMove) (bool, *BoardState, error) {
-	return NewPipeline(royaleRulesetStages...).Execute(bs, s, sm)
-}
-
-func (r *RoyaleRuleset) CreateNextBoardState(prevState *BoardState, moves []SnakeMove) (*BoardState, error) {
-	if r.StandardRuleset.HazardDamagePerTurn < 1 {
-		return nil, errors.New("royale damage per turn must be greater than zero")
-	}
-	_, nextState, err := r.Execute(prevState, r.Settings(), moves)
-	return nextState, err
-}
-
 func PopulateHazardsRoyale(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
 	if IsInitialization(b, settings, moves) {
 		return false, nil
@@ -78,16 +58,4 @@ func PopulateHazardsRoyale(b *BoardState, settings Settings, moves []SnakeMove) 
 	}
 
 	return false, nil
-}
-
-func (r *RoyaleRuleset) IsGameOver(b *BoardState) (bool, error) {
-	return GameOverStandard(b, r.Settings(), nil)
-}
-
-func (r RoyaleRuleset) Settings() Settings {
-	s := r.StandardRuleset.Settings()
-	s.RoyaleSettings = RoyaleSettings{
-		ShrinkEveryNTurns: r.ShrinkEveryNTurns,
-	}
-	return s
 }

--- a/royale.go
+++ b/royale.go
@@ -23,17 +23,18 @@ func PopulateHazardsRoyale(b *BoardState, settings Settings, moves []SnakeMove) 
 	// Royale uses the current turn to generate hazards, not the previous turn that's in the board state
 	turn := b.Turn + 1
 
-	if settings.RoyaleSettings.ShrinkEveryNTurns < 1 {
+	shrinkEveryNTurns := settings.Int(ParamShrinkEveryNTurns, 0)
+	if shrinkEveryNTurns < 1 {
 		return false, errors.New("royale game can't shrink more frequently than every turn")
 	}
 
-	if turn < settings.RoyaleSettings.ShrinkEveryNTurns {
+	if turn < shrinkEveryNTurns {
 		return false, nil
 	}
 
 	randGenerator := settings.GetRand(0)
 
-	numShrinks := turn / settings.RoyaleSettings.ShrinkEveryNTurns
+	numShrinks := turn / shrinkEveryNTurns
 	minX, maxX := 0, b.Width-1
 	minY, maxY := 0, b.Height-1
 	for i := 0; i < numShrinks; i++ {

--- a/royale_test.go
+++ b/royale_test.go
@@ -26,12 +26,12 @@ func TestRoyaleDefaultSanity(t *testing.T) {
 		},
 	}
 	r := getRoyaleRuleset(1, 0)
-	_, _, err := r.Execute(boardState, r.Settings(), []SnakeMove{{"1", "right"}, {"2", "right"}})
+	_, _, err := r.Execute(boardState, []SnakeMove{{"1", "right"}, {"2", "right"}})
 	require.Error(t, err)
 	require.Equal(t, errors.New("royale game can't shrink more frequently than every turn"), err)
 
 	r = getRoyaleRuleset(1, 1)
-	_, boardState, err = r.Execute(boardState, r.Settings(), []SnakeMove{})
+	_, boardState, err = r.Execute(boardState, []SnakeMove{})
 	require.NoError(t, err)
 	require.Len(t, boardState.Hazards, 0)
 }

--- a/royale_test.go
+++ b/royale_test.go
@@ -8,8 +8,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRoyaleRulesetInterface(t *testing.T) {
-	var _ Ruleset = (*RoyaleRuleset)(nil)
+func getRoyaleRuleset(hazardDamagePerTurn, shrinkEveryNTurns int) Ruleset {
+	settings := Settings{
+		HazardDamagePerTurn: hazardDamagePerTurn,
+		RoyaleSettings: RoyaleSettings{
+			ShrinkEveryNTurns: shrinkEveryNTurns,
+		},
+	}
+	return NewRulesetBuilder().WithSettings(settings).NamedRuleset(GameTypeRoyale)
 }
 
 func TestRoyaleDefaultSanity(t *testing.T) {
@@ -19,24 +25,19 @@ func TestRoyaleDefaultSanity(t *testing.T) {
 			{ID: "2", Body: []Point{{X: 0, Y: 1}}},
 		},
 	}
-	r := RoyaleRuleset{StandardRuleset: StandardRuleset{HazardDamagePerTurn: 1}, ShrinkEveryNTurns: 0}
-	_, err := r.CreateNextBoardState(boardState, []SnakeMove{{"1", "right"}, {"2", "right"}})
+	r := getRoyaleRuleset(1, 0)
+	_, _, err := r.Execute(boardState, r.Settings(), []SnakeMove{{"1", "right"}, {"2", "right"}})
 	require.Error(t, err)
 	require.Equal(t, errors.New("royale game can't shrink more frequently than every turn"), err)
 
-	r = RoyaleRuleset{ShrinkEveryNTurns: 1}
-	_, err = r.CreateNextBoardState(boardState, []SnakeMove{})
-	require.Error(t, err)
-	require.Equal(t, errors.New("royale damage per turn must be greater than zero"), err)
-
-	r = RoyaleRuleset{StandardRuleset: StandardRuleset{HazardDamagePerTurn: 1}, ShrinkEveryNTurns: 1}
-	boardState, err = r.CreateNextBoardState(boardState, []SnakeMove{})
+	r = getRoyaleRuleset(1, 1)
+	_, boardState, err = r.Execute(boardState, r.Settings(), []SnakeMove{})
 	require.NoError(t, err)
 	require.Len(t, boardState.Hazards, 0)
 }
 
 func TestRoyaleName(t *testing.T) {
-	r := RoyaleRuleset{}
+	r := getRoyaleRuleset(0, 0)
 	require.Equal(t, "royale", r.Name())
 }
 
@@ -204,22 +205,14 @@ func TestRoyaleCreateNextBoardState(t *testing.T) {
 		*s2,
 		royaleCaseHazardsPlaced,
 	}
-	r := RoyaleRuleset{
-		StandardRuleset: StandardRuleset{
-			HazardDamagePerTurn: 1,
-		},
-		ShrinkEveryNTurns: 1,
-	}
 	rb := NewRulesetBuilder().WithParams(map[string]string{
-		ParamGameType:            GameTypeRoyale,
 		ParamHazardDamagePerTurn: "1",
 		ParamShrinkEveryNTurns:   "1",
 	}).WithSeed(1234)
 	for _, gc := range cases {
 		rand.Seed(1234)
-		gc.requireValidNextState(t, &r)
-		// also test a RulesBuilder constructed instance
-		gc.requireValidNextState(t, rb.Ruleset())
+		// test a RulesBuilder constructed instance
+		gc.requireValidNextState(t, rb.NamedRuleset(GameTypeRoyale))
 		// also test a pipeline with the same settings
 		gc.requireValidNextState(t, rb.PipelineRuleset(GameTypeRoyale, NewPipeline(royaleRulesetStages...)))
 	}

--- a/royale_test.go
+++ b/royale_test.go
@@ -2,6 +2,7 @@ package rules
 
 import (
 	"errors"
+	"fmt"
 	"math/rand"
 	"testing"
 
@@ -9,12 +10,10 @@ import (
 )
 
 func getRoyaleRuleset(hazardDamagePerTurn, shrinkEveryNTurns int) Ruleset {
-	settings := Settings{
-		HazardDamagePerTurn: hazardDamagePerTurn,
-		RoyaleSettings: RoyaleSettings{
-			ShrinkEveryNTurns: shrinkEveryNTurns,
-		},
-	}
+	settings := NewSettingsWithParams(
+		ParamHazardDamagePerTurn, fmt.Sprint(hazardDamagePerTurn),
+		ParamShrinkEveryNTurns, fmt.Sprint(shrinkEveryNTurns),
+	)
 	return NewRulesetBuilder().WithSettings(settings).NamedRuleset(GameTypeRoyale)
 }
 
@@ -100,12 +99,10 @@ func TestRoyaleHazards(t *testing.T) {
 			Width:  test.Width,
 			Height: test.Height,
 		}
-		settings := Settings{
-			HazardDamagePerTurn: 1,
-			RoyaleSettings: RoyaleSettings{
-				ShrinkEveryNTurns: test.ShrinkEveryNTurns,
-			},
-		}.WithSeed(seed)
+		settings := NewSettingsWithParams(
+			ParamHazardDamagePerTurn, "1",
+			ParamShrinkEveryNTurns, fmt.Sprint(test.ShrinkEveryNTurns),
+		).WithSeed(seed)
 
 		_, err := PopulateHazardsRoyale(b, settings, mockSnakeMoves())
 		require.Equal(t, test.Error, err)

--- a/ruleset.go
+++ b/ruleset.go
@@ -13,9 +13,7 @@ type Ruleset interface {
 
 	// Processes the next turn of the ruleset, returning whether the game has ended, the next BoardState, or an error.
 	// For turn zero (initialization), moves will be left empty.
-	//
-	// TODO: remove settings argument - it's no longer necessary for the ruleset because it has to store and return settings already.
-	Execute(prevState *BoardState, settings Settings, moves []SnakeMove) (gameOver bool, nextState *BoardState, err error)
+	Execute(prevState *BoardState, moves []SnakeMove) (gameOver bool, nextState *BoardState, err error)
 }
 
 type SnakeMove struct {
@@ -174,8 +172,8 @@ func (r pipelineRuleset) Settings() Settings {
 func (r pipelineRuleset) Name() string { return r.name }
 
 // impl Ruleset
-func (r pipelineRuleset) Execute(bs *BoardState, s Settings, sm []SnakeMove) (bool, *BoardState, error) {
-	return r.pipeline.Execute(bs, s, sm)
+func (r pipelineRuleset) Execute(bs *BoardState, sm []SnakeMove) (bool, *BoardState, error) {
+	return r.pipeline.Execute(bs, r.Settings(), sm)
 }
 
 func (r pipelineRuleset) Err() error {

--- a/ruleset.go
+++ b/ruleset.go
@@ -1,9 +1,5 @@
 package rules
 
-import (
-	"strconv"
-)
-
 type Ruleset interface {
 	// Returns the name of the ruleset, if applicable.
 	Name() string
@@ -36,7 +32,7 @@ func NewRulesetBuilder() *rulesetBuilder {
 	}
 }
 
-// WithParams accepts a map of game parameters for customizing games.
+// WithParams accepts a map of string parameters for customizing games.
 //
 // Parameters are copied. If called multiple times, parameters are merged such that:
 //   - existing keys in both maps get overwritten by the new ones
@@ -114,47 +110,13 @@ func (rb rulesetBuilder) PipelineRuleset(name string, p Pipeline) Ruleset {
 	if rb.settings != nil {
 		settings = *rb.settings
 	} else {
-		settings = Settings{
-			FoodSpawnChance:     paramsInt(rb.params, ParamFoodSpawnChance, 0),
-			MinimumFood:         paramsInt(rb.params, ParamMinimumFood, 0),
-			HazardDamagePerTurn: paramsInt(rb.params, ParamHazardDamagePerTurn, 0),
-			HazardMap:           rb.params[ParamHazardMap],
-			HazardMapAuthor:     rb.params[ParamHazardMapAuthor],
-			RoyaleSettings: RoyaleSettings{
-				ShrinkEveryNTurns: paramsInt(rb.params, ParamShrinkEveryNTurns, 0),
-			},
-			rand: rb.rand,
-			seed: rb.seed,
-		}
+		settings = NewSettings(rb.params).WithRand(rb.rand).WithSeed(rb.seed)
 	}
 	return &pipelineRuleset{
 		name:     name,
 		pipeline: p,
 		settings: settings,
 	}
-}
-
-// paramsBool returns the boolean value for the specified parameter.
-// If the parameter doesn't exist, the default value will be returned.
-// If the parameter does exist, but is not "true", false will be returned.
-func paramsBool(params map[string]string, paramName string, defaultValue bool) bool {
-	if val, ok := params[paramName]; ok {
-		return val == "true"
-	}
-	return defaultValue
-}
-
-// paramsInt returns the int value for the specified parameter.
-// If the parameter doesn't exist, the default value will be returned.
-// If the parameter does exist, but is not a valid int, the default value will be returned.
-func paramsInt(params map[string]string, paramName string, defaultValue int) int {
-	if val, ok := params[paramName]; ok {
-		i, err := strconv.Atoi(val)
-		if err == nil {
-			return i
-		}
-	}
-	return defaultValue
 }
 
 type pipelineRuleset struct {

--- a/ruleset.go
+++ b/ruleset.go
@@ -5,12 +5,17 @@ import (
 )
 
 type Ruleset interface {
+	// Returns the name of the ruleset, if applicable.
 	Name() string
-	ModifyInitialBoardState(initialState *BoardState) (*BoardState, error)
-	CreateNextBoardState(prevState *BoardState, moves []SnakeMove) (*BoardState, error)
-	IsGameOver(state *BoardState) (bool, error)
-	// Settings provides the game settings that are relevant to the ruleset.
+
+	// Returns the settings used by the ruleset.
 	Settings() Settings
+
+	// Processes the next turn of the ruleset, returning whether the game has ended, the next BoardState, or an error.
+	// For turn zero (initialization), moves will be left empty.
+	//
+	// TODO: remove settings argument - it's no longer necessary for the ruleset because it has to store and return settings already.
+	Execute(prevState *BoardState, settings Settings, moves []SnakeMove) (gameOver bool, nextState *BoardState, err error)
 }
 
 type SnakeMove struct {
@@ -18,68 +23,12 @@ type SnakeMove struct {
 	Move string
 }
 
-// Settings contains all settings relevant to a game.
-// It is used by game logic to take a previous game state and produce a next game state.
-type Settings struct {
-	FoodSpawnChance     int            `json:"foodSpawnChance"`
-	MinimumFood         int            `json:"minimumFood"`
-	HazardDamagePerTurn int            `json:"hazardDamagePerTurn"`
-	HazardMap           string         `json:"hazardMap"`
-	HazardMapAuthor     string         `json:"hazardMapAuthor"`
-	RoyaleSettings      RoyaleSettings `json:"royale"`
-	SquadSettings       SquadSettings  `json:"squad"` // Deprecated, provided with default fields for API compatibility
-
-	rand Rand
-	seed int64
-}
-
-// Get a random number generator initialized based on the seed and current turn.
-func (settings Settings) GetRand(turn int) Rand {
-	// Allow overriding the random generator for testing
-	if settings.rand != nil {
-		return settings.rand
-	}
-
-	if settings.seed != 0 {
-		return NewSeedRand(settings.seed + int64(turn))
-	}
-
-	// Default to global random number generator if neither seed or rand are set.
-	return GlobalRand
-}
-
-func (settings Settings) WithRand(rand Rand) Settings {
-	settings.rand = rand
-	return settings
-}
-
-func (settings Settings) Seed() int64 {
-	return settings.seed
-}
-
-func (settings Settings) WithSeed(seed int64) Settings {
-	settings.seed = seed
-	return settings
-}
-
-// RoyaleSettings contains settings that are specific to the "royale" game mode
-type RoyaleSettings struct {
-	ShrinkEveryNTurns int `json:"shrinkEveryNTurns"`
-}
-
-// SquadSettings contains settings that are specific to the "squad" game mode
-type SquadSettings struct {
-	AllowBodyCollisions bool `json:"allowBodyCollisions"`
-	SharedElimination   bool `json:"sharedElimination"`
-	SharedHealth        bool `json:"sharedHealth"`
-	SharedLength        bool `json:"sharedLength"`
-}
-
 type rulesetBuilder struct {
-	params map[string]string // game customisation parameters
-	seed   int64             // used for random events in games
-	rand   Rand              // used for random number generation
-	solo   bool              // if true, only 1 alive snake is required to keep the game from ending
+	params   map[string]string // game customisation parameters
+	seed     int64             // used for random events in games
+	rand     Rand              // used for random number generation
+	solo     bool              // if true, only 1 alive snake is required to keep the game from ending
+	settings *Settings         // used to set settings directly instead of via string params
 }
 
 // NewRulesetBuilder returns an instance of a builder for the Ruleset types.
@@ -125,13 +74,14 @@ func (rb *rulesetBuilder) WithSolo(value bool) *rulesetBuilder {
 	return rb
 }
 
-// Ruleset constructs a customised ruleset using the parameters passed to the builder.
-func (rb rulesetBuilder) Ruleset() PipelineRuleset {
-	name, ok := rb.params[ParamGameType]
-	if !ok {
-		name = GameTypeStandard
-	}
+// WithSettings sets the settings object for the ruleset directly.
+func (rb *rulesetBuilder) WithSettings(settings Settings) *rulesetBuilder {
+	rb.settings = &settings
+	return rb
+}
 
+// NamedRuleset constructs a known ruleset by using name to look up a standard pipeline.
+func (rb rulesetBuilder) NamedRuleset(name string) Ruleset {
 	var stages []string
 	if rb.solo {
 		stages = append(stages, StageGameOverSoloSnake)
@@ -153,19 +103,20 @@ func (rb rulesetBuilder) Ruleset() PipelineRuleset {
 	case GameTypeWrapped:
 		stages = append(stages, wrappedRulesetStages[1:]...)
 	default:
+		name = GameTypeStandard
 		stages = append(stages, standardRulesetStages[1:]...)
 	}
 	return rb.PipelineRuleset(name, NewPipeline(stages...))
 }
 
-// PipelineRuleset provides an implementation of the Ruleset using a pipeline with a name.
-// It is intended to facilitate transitioning away from legacy Ruleset implementations to Pipeline
-// implementations.
-func (rb rulesetBuilder) PipelineRuleset(name string, p Pipeline) PipelineRuleset {
-	return &pipelineRuleset{
-		name:     name,
-		pipeline: p,
-		settings: Settings{
+// PipelineRuleset constructs a ruleset with the given name and pipeline using the parameters passed to the builder.
+// This can be used to create custom rulesets.
+func (rb rulesetBuilder) PipelineRuleset(name string, p Pipeline) Ruleset {
+	var settings Settings
+	if rb.settings != nil {
+		settings = *rb.settings
+	} else {
+		settings = Settings{
 			FoodSpawnChance:     paramsInt(rb.params, ParamFoodSpawnChance, 0),
 			MinimumFood:         paramsInt(rb.params, ParamMinimumFood, 0),
 			HazardDamagePerTurn: paramsInt(rb.params, ParamHazardDamagePerTurn, 0),
@@ -176,7 +127,12 @@ func (rb rulesetBuilder) PipelineRuleset(name string, p Pipeline) PipelineRulese
 			},
 			rand: rb.rand,
 			seed: rb.seed,
-		},
+		}
+	}
+	return &pipelineRuleset{
+		name:     name,
+		pipeline: p,
+		settings: settings,
 	}
 }
 
@@ -203,13 +159,6 @@ func paramsInt(params map[string]string, paramName string, defaultValue int) int
 	return defaultValue
 }
 
-// PipelineRuleset groups the Pipeline and Ruleset methods.
-// It is intended to facilitate a transition from Ruleset legacy code to Pipeline code.
-type PipelineRuleset interface {
-	Ruleset
-	Pipeline
-}
-
 type pipelineRuleset struct {
 	pipeline Pipeline
 	name     string
@@ -225,33 +174,10 @@ func (r pipelineRuleset) Settings() Settings {
 func (r pipelineRuleset) Name() string { return r.name }
 
 // impl Ruleset
-// IMPORTANT: this implementation of IsGameOver deviates from the previous Ruleset implementations
-// in that it checks if the *NEXT* state results in game over, not the previous state.
-// This is due to the design of pipelines / stage functions not having a distinction between
-// checking for game over and producing a next state.
-func (r *pipelineRuleset) IsGameOver(b *BoardState) (bool, error) {
-	gameover, _, err := r.Execute(b, r.Settings(), nil) // checks if next state is game over
-	return gameover, err
-}
-
-// impl Ruleset
-func (r pipelineRuleset) ModifyInitialBoardState(initialState *BoardState) (*BoardState, error) {
-	_, nextState, err := r.Execute(initialState, r.Settings(), nil)
-	return nextState, err
-}
-
-// impl Pipeline
 func (r pipelineRuleset) Execute(bs *BoardState, s Settings, sm []SnakeMove) (bool, *BoardState, error) {
 	return r.pipeline.Execute(bs, s, sm)
 }
 
-// impl Ruleset
-func (r pipelineRuleset) CreateNextBoardState(bs *BoardState, sm []SnakeMove) (*BoardState, error) {
-	_, nextState, err := r.Execute(bs, r.Settings(), sm)
-	return nextState, err
-}
-
-// impl Pipeline
 func (r pipelineRuleset) Err() error {
 	return r.pipeline.Err()
 }

--- a/ruleset_internal_test.go
+++ b/ruleset_internal_test.go
@@ -42,10 +42,10 @@ func TestRulesetError(t *testing.T) {
 
 func TestRulesetBuilderInternals(t *testing.T) {
 	// test Royale with seed
-	rsb := NewRulesetBuilder().WithSeed(3).WithParams(map[string]string{ParamGameType: GameTypeRoyale})
+	rsb := NewRulesetBuilder().WithSeed(3)
 	require.Equal(t, int64(3), rsb.seed)
-	require.Equal(t, GameTypeRoyale, rsb.Ruleset().Name())
-	require.Equal(t, int64(3), rsb.Ruleset().Settings().Seed())
+	require.Equal(t, GameTypeRoyale, rsb.NamedRuleset(GameTypeRoyale).Name())
+	require.Equal(t, int64(3), rsb.NamedRuleset(GameTypeRoyale).Settings().Seed())
 
 	// test parameter merging
 	rsb = NewRulesetBuilder().

--- a/ruleset_internal_test.go
+++ b/ruleset_internal_test.go
@@ -10,31 +10,6 @@ import (
 	_ "github.com/BattlesnakeOfficial/rules/test"
 )
 
-func TestParamInt(t *testing.T) {
-	require.Equal(t, 5, paramsInt(nil, "test", 5), "nil map")
-	require.Equal(t, 10, paramsInt(map[string]string{}, "foo", 10), "empty map")
-	require.Equal(t, 10, paramsInt(map[string]string{"hullo": "there"}, "hullo", 10), "invalid value")
-	require.Equal(t, 20, paramsInt(map[string]string{"bonjour": "20"}, "bonjour", 20), "valid value")
-}
-
-func TestParamBool(t *testing.T) {
-	// missing values default to specified value
-	require.Equal(t, true, paramsBool(nil, "test", true), "nil map true")
-	require.Equal(t, false, paramsBool(nil, "test", false), "nil map false")
-
-	// missing values default to specified value
-	require.Equal(t, true, paramsBool(map[string]string{}, "foo", true), "empty map true")
-	require.Equal(t, false, paramsBool(map[string]string{}, "foo", false), "empty map false")
-
-	// invalid values (exist but not booL) default to false
-	require.Equal(t, false, paramsBool(map[string]string{"hullo": "there"}, "hullo", true), "invalid value default true")
-	require.Equal(t, false, paramsBool(map[string]string{"hullo": "there"}, "hullo", false), "invalid value default false")
-
-	// valid values ignore defaults
-	require.Equal(t, false, paramsBool(map[string]string{"bonjour": "false"}, "bonjour", false), "valid value false")
-	require.Equal(t, true, paramsBool(map[string]string{"bonjour": "true"}, "bonjour", false), "valid value true")
-}
-
 func TestRulesetError(t *testing.T) {
 	err := (error)(RulesetError("test error string"))
 	require.Equal(t, "test error string", err.Error())

--- a/ruleset_test.go
+++ b/ruleset_test.go
@@ -5,102 +5,13 @@ import (
 	"testing"
 
 	"github.com/BattlesnakeOfficial/rules"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestStandardRulesetSettings(t *testing.T) {
-	ruleset := rules.StandardRuleset{
-		MinimumFood:         5,
-		FoodSpawnChance:     10,
-		HazardDamagePerTurn: 10,
-		HazardMap:           "hz_spiral",
-		HazardMapAuthor:     "altersaddle",
-	}
-	assert.Equal(t, ruleset.MinimumFood, ruleset.Settings().MinimumFood)
-	assert.Equal(t, ruleset.FoodSpawnChance, ruleset.Settings().FoodSpawnChance)
-	assert.Equal(t, ruleset.HazardDamagePerTurn, ruleset.Settings().HazardDamagePerTurn)
-	assert.Equal(t, ruleset.HazardMap, ruleset.Settings().HazardMap)
-	assert.Equal(t, ruleset.HazardMapAuthor, ruleset.Settings().HazardMapAuthor)
-}
-
-func TestWrappedRulesetSettings(t *testing.T) {
-	ruleset := rules.WrappedRuleset{
-		StandardRuleset: rules.StandardRuleset{
-			MinimumFood:         5,
-			FoodSpawnChance:     10,
-			HazardDamagePerTurn: 10,
-			HazardMap:           "hz_spiral",
-			HazardMapAuthor:     "altersaddle",
-		},
-	}
-	assert.Equal(t, ruleset.MinimumFood, ruleset.Settings().MinimumFood)
-	assert.Equal(t, ruleset.FoodSpawnChance, ruleset.Settings().FoodSpawnChance)
-	assert.Equal(t, ruleset.HazardDamagePerTurn, ruleset.Settings().HazardDamagePerTurn)
-	assert.Equal(t, ruleset.HazardMap, ruleset.Settings().HazardMap)
-	assert.Equal(t, ruleset.HazardMapAuthor, ruleset.Settings().HazardMapAuthor)
-}
-
-func TestSoloRulesetSettings(t *testing.T) {
-	ruleset := rules.SoloRuleset{
-		StandardRuleset: rules.StandardRuleset{
-			MinimumFood:         5,
-			FoodSpawnChance:     10,
-			HazardDamagePerTurn: 10,
-			HazardMap:           "hz_spiral",
-			HazardMapAuthor:     "altersaddle",
-		},
-	}
-	assert.Equal(t, ruleset.MinimumFood, ruleset.Settings().MinimumFood)
-	assert.Equal(t, ruleset.FoodSpawnChance, ruleset.Settings().FoodSpawnChance)
-	assert.Equal(t, ruleset.HazardDamagePerTurn, ruleset.Settings().HazardDamagePerTurn)
-	assert.Equal(t, ruleset.HazardMap, ruleset.Settings().HazardMap)
-	assert.Equal(t, ruleset.HazardMapAuthor, ruleset.Settings().HazardMapAuthor)
-}
-
-func TestRoyaleRulesetSettings(t *testing.T) {
-	ruleset := rules.RoyaleRuleset{
-		ShrinkEveryNTurns: 12,
-		StandardRuleset: rules.StandardRuleset{
-			MinimumFood:         5,
-			FoodSpawnChance:     10,
-			HazardDamagePerTurn: 10,
-			HazardMap:           "hz_spiral",
-			HazardMapAuthor:     "altersaddle",
-		},
-	}
-	assert.Equal(t, ruleset.ShrinkEveryNTurns, ruleset.Settings().RoyaleSettings.ShrinkEveryNTurns)
-	assert.Equal(t, ruleset.MinimumFood, ruleset.Settings().MinimumFood)
-	assert.Equal(t, ruleset.FoodSpawnChance, ruleset.Settings().FoodSpawnChance)
-	assert.Equal(t, ruleset.HazardDamagePerTurn, ruleset.Settings().HazardDamagePerTurn)
-	assert.Equal(t, ruleset.HazardMap, ruleset.Settings().HazardMap)
-	assert.Equal(t, ruleset.HazardMapAuthor, ruleset.Settings().HazardMapAuthor)
-}
-
-func TestConstrictorRulesetSettings(t *testing.T) {
-	ruleset := rules.ConstrictorRuleset{
-		StandardRuleset: rules.StandardRuleset{
-			MinimumFood:         5,
-			FoodSpawnChance:     10,
-			HazardDamagePerTurn: 10,
-			HazardMap:           "hz_spiral",
-			HazardMapAuthor:     "altersaddle",
-		},
-	}
-	assert.Equal(t, ruleset.MinimumFood, ruleset.Settings().MinimumFood)
-	assert.Equal(t, ruleset.FoodSpawnChance, ruleset.Settings().FoodSpawnChance)
-	assert.Equal(t, ruleset.HazardDamagePerTurn, ruleset.Settings().HazardDamagePerTurn)
-	assert.Equal(t, ruleset.HazardMap, ruleset.Settings().HazardMap)
-	assert.Equal(t, ruleset.HazardMapAuthor, ruleset.Settings().HazardMapAuthor)
-}
-
 func TestRulesetBuilder(t *testing.T) {
 	// Test that a fresh instance can produce a Ruleset
-	require.NotNil(t, rules.NewRulesetBuilder().Ruleset())
-	require.Equal(t, rules.GameTypeStandard, rules.NewRulesetBuilder().Ruleset().Name(), "should default to standard game")
-
-	// test nil safety / defaults
-	require.NotNil(t, rules.NewRulesetBuilder().Ruleset())
+	require.NotNil(t, rules.NewRulesetBuilder().NamedRuleset(""))
+	require.Equal(t, rules.GameTypeStandard, rules.NewRulesetBuilder().NamedRuleset("").Name(), "should default to standard game")
 
 	// make sure it works okay for lots of game types
 	expectedResults := []struct {
@@ -120,7 +31,6 @@ func TestRulesetBuilder(t *testing.T) {
 
 			rsb.WithParams(map[string]string{
 				// apply the standard rule params
-				rules.ParamGameType:            expected.GameType,
 				rules.ParamFoodSpawnChance:     "10",
 				rules.ParamMinimumFood:         "5",
 				rules.ParamHazardDamagePerTurn: "12",
@@ -128,14 +38,14 @@ func TestRulesetBuilder(t *testing.T) {
 				rules.ParamHazardMapAuthor:     "tester",
 			})
 
-			require.NotNil(t, rsb.Ruleset())
-			require.Equal(t, expected.GameType, rsb.Ruleset().Name())
+			require.NotNil(t, rsb.NamedRuleset(expected.GameType))
+			require.Equal(t, expected.GameType, rsb.NamedRuleset(expected.GameType).Name())
 			// All the standard settings should always be copied over
-			require.Equal(t, 10, rsb.Ruleset().Settings().FoodSpawnChance)
-			require.Equal(t, 12, rsb.Ruleset().Settings().HazardDamagePerTurn)
-			require.Equal(t, 5, rsb.Ruleset().Settings().MinimumFood)
-			require.Equal(t, "test", rsb.Ruleset().Settings().HazardMap)
-			require.Equal(t, "tester", rsb.Ruleset().Settings().HazardMapAuthor)
+			require.Equal(t, 10, rsb.NamedRuleset(expected.GameType).Settings().FoodSpawnChance)
+			require.Equal(t, 12, rsb.NamedRuleset(expected.GameType).Settings().HazardDamagePerTurn)
+			require.Equal(t, 5, rsb.NamedRuleset(expected.GameType).Settings().MinimumFood)
+			require.Equal(t, "test", rsb.NamedRuleset(expected.GameType).Settings().HazardMap)
+			require.Equal(t, "tester", rsb.NamedRuleset(expected.GameType).Settings().HazardMapAuthor)
 		})
 	}
 }
@@ -214,11 +124,9 @@ func TestRulesetBuilderGameOver(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%v_%v", test.gameType, test.solo), func(t *testing.T) {
-			rsb := rules.NewRulesetBuilder().WithParams(map[string]string{
-				rules.ParamGameType: test.gameType,
-			}).WithSolo(test.solo)
+			rsb := rules.NewRulesetBuilder().WithSolo(test.solo)
 
-			ruleset := rsb.Ruleset()
+			ruleset := rsb.NamedRuleset(test.gameType)
 
 			gameOver, _, err := ruleset.Execute(boardState, settings, moves)
 
@@ -234,7 +142,7 @@ func TestStageFuncContract(t *testing.T) {
 	stage = func(bs *rules.BoardState, s rules.Settings, sm []rules.SnakeMove) (bool, error) {
 		return true, nil
 	}
-	ended, err := stage(nil, rules.NewRulesetBuilder().Ruleset().Settings(), nil)
+	ended, err := stage(nil, rules.NewRulesetBuilder().NamedRuleset("").Settings(), nil)
 	require.NoError(t, err)
 	require.True(t, ended)
 }

--- a/ruleset_test.go
+++ b/ruleset_test.go
@@ -34,28 +34,20 @@ func TestRulesetBuilder(t *testing.T) {
 				rules.ParamFoodSpawnChance:     "10",
 				rules.ParamMinimumFood:         "5",
 				rules.ParamHazardDamagePerTurn: "12",
-				rules.ParamHazardMap:           "test",
-				rules.ParamHazardMapAuthor:     "tester",
 			})
 
 			require.NotNil(t, rsb.NamedRuleset(expected.GameType))
 			require.Equal(t, expected.GameType, rsb.NamedRuleset(expected.GameType).Name())
 			// All the standard settings should always be copied over
-			require.Equal(t, 10, rsb.NamedRuleset(expected.GameType).Settings().FoodSpawnChance)
-			require.Equal(t, 12, rsb.NamedRuleset(expected.GameType).Settings().HazardDamagePerTurn)
-			require.Equal(t, 5, rsb.NamedRuleset(expected.GameType).Settings().MinimumFood)
-			require.Equal(t, "test", rsb.NamedRuleset(expected.GameType).Settings().HazardMap)
-			require.Equal(t, "tester", rsb.NamedRuleset(expected.GameType).Settings().HazardMapAuthor)
+			require.Equal(t, 10, rsb.NamedRuleset(expected.GameType).Settings().Int(rules.ParamFoodSpawnChance, 0))
+			require.Equal(t, 12, rsb.NamedRuleset(expected.GameType).Settings().Int(rules.ParamHazardDamagePerTurn, 0))
+			require.Equal(t, 5, rsb.NamedRuleset(expected.GameType).Settings().Int(rules.ParamMinimumFood, 0))
 		})
 	}
 }
 
 func TestRulesetBuilderGameOver(t *testing.T) {
-	settings := rules.Settings{
-		RoyaleSettings: rules.RoyaleSettings{
-			ShrinkEveryNTurns: 12,
-		},
-	}
+	settings := rules.NewSettingsWithParams(rules.ParamShrinkEveryNTurns, "12")
 	moves := []rules.SnakeMove{
 		{ID: "1", Move: "up"},
 	}

--- a/ruleset_test.go
+++ b/ruleset_test.go
@@ -124,11 +124,11 @@ func TestRulesetBuilderGameOver(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%v_%v", test.gameType, test.solo), func(t *testing.T) {
-			rsb := rules.NewRulesetBuilder().WithSolo(test.solo)
+			rsb := rules.NewRulesetBuilder().WithSettings(settings).WithSolo(test.solo)
 
 			ruleset := rsb.NamedRuleset(test.gameType)
 
-			gameOver, _, err := ruleset.Execute(boardState, settings, moves)
+			gameOver, _, err := ruleset.Execute(boardState, moves)
 
 			require.NoError(t, err)
 			require.Equal(t, test.gameOver, gameOver)

--- a/settings.go
+++ b/settings.go
@@ -1,0 +1,58 @@
+package rules
+
+// Settings contains all settings relevant to a game.
+// It is used by game logic to take a previous game state and produce a next game state.
+type Settings struct {
+	FoodSpawnChance     int            `json:"foodSpawnChance"`
+	MinimumFood         int            `json:"minimumFood"`
+	HazardDamagePerTurn int            `json:"hazardDamagePerTurn"`
+	HazardMap           string         `json:"hazardMap"`
+	HazardMapAuthor     string         `json:"hazardMapAuthor"`
+	RoyaleSettings      RoyaleSettings `json:"royale"`
+	SquadSettings       SquadSettings  `json:"squad"` // Deprecated, provided with default fields for API compatibility
+
+	rand Rand
+	seed int64
+}
+
+// Get a random number generator initialized based on the seed and current turn.
+func (settings Settings) GetRand(turn int) Rand {
+	// Allow overriding the random generator for testing
+	if settings.rand != nil {
+		return settings.rand
+	}
+
+	if settings.seed != 0 {
+		return NewSeedRand(settings.seed + int64(turn))
+	}
+
+	// Default to global random number generator if neither seed or rand are set.
+	return GlobalRand
+}
+
+func (settings Settings) WithRand(rand Rand) Settings {
+	settings.rand = rand
+	return settings
+}
+
+func (settings Settings) Seed() int64 {
+	return settings.seed
+}
+
+func (settings Settings) WithSeed(seed int64) Settings {
+	settings.seed = seed
+	return settings
+}
+
+// RoyaleSettings contains settings that are specific to the "royale" game mode
+type RoyaleSettings struct {
+	ShrinkEveryNTurns int `json:"shrinkEveryNTurns"`
+}
+
+// SquadSettings contains settings that are specific to the "squad" game mode
+type SquadSettings struct {
+	AllowBodyCollisions bool `json:"allowBodyCollisions"`
+	SharedElimination   bool `json:"sharedElimination"`
+	SharedHealth        bool `json:"sharedHealth"`
+	SharedLength        bool `json:"sharedLength"`
+}

--- a/settings_test.go
+++ b/settings_test.go
@@ -1,0 +1,31 @@
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/BattlesnakeOfficial/rules"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSettings(t *testing.T) {
+	params := map[string]string{
+		"invalidSetting": "abcd",
+		"intSetting":     "1234",
+		"boolSetting":    "true",
+	}
+
+	settings := rules.NewSettings(params)
+
+	assert.Equal(t, 4567, settings.Int("missingIntSetting", 4567))
+	assert.Equal(t, 4567, settings.Int("invalidSetting", 4567))
+	assert.Equal(t, 1234, settings.Int("intSetting", 4567))
+
+	assert.Equal(t, false, settings.Bool("missingBoolSetting", false))
+	assert.Equal(t, true, settings.Bool("missingBoolSetting", true))
+	assert.Equal(t, false, settings.Bool("invalidSetting", true))
+	assert.Equal(t, true, settings.Bool("boolSetting", true))
+
+	assert.Equal(t, 4567, rules.NewSettingsWithParams("newIntSetting").Int("newIntSetting", 4567))
+	assert.Equal(t, 1234, rules.NewSettingsWithParams("newIntSetting", "1234").Int("newIntSetting", 4567))
+	assert.Equal(t, 4567, rules.NewSettingsWithParams("x", "y", "newIntSetting").Int("newIntSetting", 4567))
+}

--- a/solo.go
+++ b/solo.go
@@ -9,25 +9,6 @@ var soloRulesetStages = []string{
 	StageEliminationStandard,
 }
 
-type SoloRuleset struct {
-	StandardRuleset
-}
-
-func (r *SoloRuleset) Name() string { return GameTypeSolo }
-
-func (r SoloRuleset) Execute(bs *BoardState, s Settings, sm []SnakeMove) (bool, *BoardState, error) {
-	return NewPipeline(soloRulesetStages...).Execute(bs, s, sm)
-}
-
-func (r *SoloRuleset) CreateNextBoardState(prevState *BoardState, moves []SnakeMove) (*BoardState, error) {
-	_, nextState, err := r.Execute(prevState, r.Settings(), moves)
-	return nextState, err
-}
-
-func (r *SoloRuleset) IsGameOver(b *BoardState) (bool, error) {
-	return GameOverSolo(b, r.Settings(), nil)
-}
-
 func GameOverSolo(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
 	for i := 0; i < len(b.Snakes); i++ {
 		if b.Snakes[i].EliminatedCause == NotEliminated {

--- a/solo_test.go
+++ b/solo_test.go
@@ -18,7 +18,7 @@ func TestSoloName(t *testing.T) {
 func TestSoloCreateNextBoardStateSanity(t *testing.T) {
 	boardState := &BoardState{}
 	r := getSoloRuleset(Settings{})
-	gameOver, _, err := r.Execute(boardState, r.Settings(), []SnakeMove{})
+	gameOver, _, err := r.Execute(boardState, []SnakeMove{})
 	require.NoError(t, err)
 	require.True(t, gameOver)
 }
@@ -51,7 +51,7 @@ func TestSoloIsGameOver(t *testing.T) {
 			Food:   []Point{},
 		}
 
-		actual, _, err := r.Execute(b, r.Settings(), nil)
+		actual, _, err := r.Execute(b, nil)
 		require.NoError(t, err)
 		require.Equal(t, test.Expected, actual)
 	}
@@ -123,19 +123,11 @@ func TestSoloEliminationOutOfBounds(t *testing.T) {
 	initialState, err := CreateDefaultBoardState(MaxRand, 2, 2, []string{"one"})
 	require.NoError(t, err)
 
-	_, next, err := r.Execute(
-		initialState,
-		r.Settings(),
-		[]SnakeMove{{ID: "one", Move: "right"}},
-	)
+	_, next, err := r.Execute(initialState, []SnakeMove{{ID: "one", Move: "right"}})
 	require.NoError(t, err)
 	require.NotNil(t, initialState)
 
-	ended, next, err := r.Execute(
-		next,
-		r.Settings(),
-		[]SnakeMove{{ID: "one", Move: "right"}},
-	)
+	ended, next, err := r.Execute(next, []SnakeMove{{ID: "one", Move: "right"}})
 	require.NoError(t, err)
 	require.NotNil(t, initialState)
 

--- a/solo_test.go
+++ b/solo_test.go
@@ -6,20 +6,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSoloRulesetInterface(t *testing.T) {
-	var _ Ruleset = (*SoloRuleset)(nil)
+func getSoloRuleset(settings Settings) Ruleset {
+	return NewRulesetBuilder().WithSettings(settings).NamedRuleset(GameTypeSolo)
 }
 
 func TestSoloName(t *testing.T) {
-	r := SoloRuleset{}
+	r := getSoloRuleset(Settings{})
 	require.Equal(t, "solo", r.Name())
 }
 
 func TestSoloCreateNextBoardStateSanity(t *testing.T) {
 	boardState := &BoardState{}
-	r := SoloRuleset{}
-	_, err := r.CreateNextBoardState(boardState, []SnakeMove{})
+	r := getSoloRuleset(Settings{})
+	gameOver, _, err := r.Execute(boardState, r.Settings(), []SnakeMove{})
 	require.NoError(t, err)
+	require.True(t, gameOver)
 }
 
 func TestSoloIsGameOver(t *testing.T) {
@@ -41,7 +42,7 @@ func TestSoloIsGameOver(t *testing.T) {
 		},
 	}
 
-	r := SoloRuleset{}
+	r := getSoloRuleset(Settings{})
 	for _, test := range tests {
 		b := &BoardState{
 			Height: 11,
@@ -50,7 +51,7 @@ func TestSoloIsGameOver(t *testing.T) {
 			Food:   []Point{},
 		}
 
-		actual, err := r.IsGameOver(b)
+		actual, _, err := r.Execute(b, r.Settings(), nil)
 		require.NoError(t, err)
 		require.Equal(t, test.Expected, actual)
 	}
@@ -104,14 +105,10 @@ func TestSoloCreateNextBoardState(t *testing.T) {
 		standardMoveAndCollideMAD,
 		soloCaseNotOver,
 	}
-	r := SoloRuleset{}
-	rb := NewRulesetBuilder().WithParams(map[string]string{
-		ParamGameType: GameTypeSolo,
-	})
+	r := getSoloRuleset(Settings{})
 	for _, gc := range cases {
-		gc.requireValidNextState(t, &r)
-		// also test a RulesBuilder constructed instance
-		gc.requireValidNextState(t, rb.Ruleset())
+		// test a RulesBuilder constructed instance
+		gc.requireValidNextState(t, r)
 		// also test a pipeline with the same settings
 		gc.requireValidNextState(t, NewRulesetBuilder().PipelineRuleset(GameTypeSolo, NewPipeline(soloRulesetStages...)))
 	}
@@ -119,7 +116,7 @@ func TestSoloCreateNextBoardState(t *testing.T) {
 
 // Test a snake running right into the wall is properly eliminated
 func TestSoloEliminationOutOfBounds(t *testing.T) {
-	r := SoloRuleset{}
+	r := getSoloRuleset(Settings{})
 
 	// Using MaxRand is important because it ensures that the snakes are consistently placed in a way this test will work.
 	// Actually random placement could result in the assumptions made by this test being incorrect.

--- a/standard.go
+++ b/standard.go
@@ -5,14 +5,6 @@ import (
 	"sort"
 )
 
-type StandardRuleset struct {
-	FoodSpawnChance     int // [0, 100]
-	MinimumFood         int
-	HazardDamagePerTurn int
-	HazardMap           string // optional
-	HazardMapAuthor     string // optional
-}
-
 var standardRulesetStages = []string{
 	StageGameOverStandard,
 	StageMovementStandard,
@@ -20,23 +12,6 @@ var standardRulesetStages = []string{
 	StageHazardDamageStandard,
 	StageFeedSnakesStandard,
 	StageEliminationStandard,
-}
-
-func (r *StandardRuleset) Name() string { return GameTypeStandard }
-
-func (r *StandardRuleset) ModifyInitialBoardState(initialState *BoardState) (*BoardState, error) {
-	// No-op
-	return initialState, nil
-}
-
-// impl Pipeline
-func (r StandardRuleset) Execute(bs *BoardState, s Settings, sm []SnakeMove) (bool, *BoardState, error) {
-	return NewPipeline(standardRulesetStages...).Execute(bs, s, sm)
-}
-
-func (r *StandardRuleset) CreateNextBoardState(prevState *BoardState, moves []SnakeMove) (*BoardState, error) {
-	_, nextState, err := r.Execute(prevState, r.Settings(), moves)
-	return nextState, err
 }
 
 func MoveSnakesStandard(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
@@ -403,10 +378,6 @@ func SpawnFoodStandard(b *BoardState, settings Settings, moves []SnakeMove) (boo
 	return false, nil
 }
 
-func (r *StandardRuleset) IsGameOver(b *BoardState) (bool, error) {
-	return GameOverStandard(b, r.Settings(), nil)
-}
-
 func GameOverStandard(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
 	numSnakesRemaining := 0
 	for i := 0; i < len(b.Snakes); i++ {
@@ -415,26 +386,4 @@ func GameOverStandard(b *BoardState, settings Settings, moves []SnakeMove) (bool
 		}
 	}
 	return numSnakesRemaining <= 1, nil
-}
-
-func (r StandardRuleset) Settings() Settings {
-	return Settings{
-		FoodSpawnChance:     r.FoodSpawnChance,
-		MinimumFood:         r.MinimumFood,
-		HazardDamagePerTurn: r.HazardDamagePerTurn,
-		HazardMap:           r.HazardMap,
-		HazardMapAuthor:     r.HazardMapAuthor,
-	}
-}
-
-// impl Pipeline
-func (r StandardRuleset) Err() error {
-	return nil
-}
-
-// IsInitialization checks whether the current state means the game is initialising.
-func IsInitialization(b *BoardState, settings Settings, moves []SnakeMove) bool {
-	// We can safely assume that the game state is in the initialisation phase when
-	// the turn hasn't advanced and the moves are empty
-	return b.Turn <= 0 && len(moves) == 0
 }

--- a/standard.go
+++ b/standard.go
@@ -131,6 +131,7 @@ func DamageHazardsStandard(b *BoardState, settings Settings, moves []SnakeMove) 
 	if IsInitialization(b, settings, moves) {
 		return false, nil
 	}
+	hazardDamage := settings.Int(ParamHazardDamagePerTurn, 0)
 	for i := 0; i < len(b.Snakes); i++ {
 		snake := &b.Snakes[i]
 		if snake.EliminatedCause != NotEliminated {
@@ -151,7 +152,7 @@ func DamageHazardsStandard(b *BoardState, settings Settings, moves []SnakeMove) 
 				}
 
 				// Snake is in a hazard, reduce health
-				snake.Health = snake.Health - settings.HazardDamagePerTurn
+				snake.Health = snake.Health - hazardDamage
 				if snake.Health < 0 {
 					snake.Health = 0
 				}
@@ -368,11 +369,13 @@ func SpawnFoodStandard(b *BoardState, settings Settings, moves []SnakeMove) (boo
 	if IsInitialization(b, settings, moves) {
 		return false, nil
 	}
+	minimumFood := settings.Int(ParamMinimumFood, 0)
+	foodSpawnChance := settings.Int(ParamFoodSpawnChance, 0)
 	numCurrentFood := int(len(b.Food))
-	if numCurrentFood < settings.MinimumFood {
-		return false, PlaceFoodRandomly(GlobalRand, b, settings.MinimumFood-numCurrentFood)
+	if numCurrentFood < minimumFood {
+		return false, PlaceFoodRandomly(GlobalRand, b, minimumFood-numCurrentFood)
 	}
-	if settings.FoodSpawnChance > 0 && int(rand.Intn(100)) < settings.FoodSpawnChance {
+	if foodSpawnChance > 0 && int(rand.Intn(100)) < foodSpawnChance {
 		return false, PlaceFoodRandomly(GlobalRand, b, 1)
 	}
 	return false, nil

--- a/standard_test.go
+++ b/standard_test.go
@@ -19,7 +19,7 @@ func TestSanity(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, state)
 
-	gameOver, state, err := r.Execute(state, r.Settings(), []SnakeMove{})
+	gameOver, state, err := r.Execute(state, []SnakeMove{})
 	require.NoError(t, err)
 	require.True(t, gameOver)
 	require.NotNil(t, state)
@@ -280,7 +280,7 @@ func TestEatingOnLastMove(t *testing.T) {
 	rand.Seed(0) // Seed with a value that will reliably not spawn food
 	r := getStandardRuleset(Settings{})
 	for _, test := range tests {
-		_, nextState, err := r.Execute(test.prevState, r.Settings(), test.moves)
+		_, nextState, err := r.Execute(test.prevState, test.moves)
 		require.Equal(t, err, test.expectedError)
 		if test.expectedState != nil {
 			require.Equal(t, test.expectedState.Width, nextState.Width)
@@ -402,7 +402,7 @@ func TestHeadToHeadOnFood(t *testing.T) {
 	rand.Seed(0) // Seed with a value that will reliably not spawn food
 	r := getStandardRuleset(Settings{})
 	for _, test := range tests {
-		_, nextState, err := r.Execute(test.prevState, r.Settings(), test.moves)
+		_, nextState, err := r.Execute(test.prevState, test.moves)
 		require.Equal(t, test.expectedError, err)
 		if test.expectedState != nil {
 			require.Equal(t, test.expectedState.Width, nextState.Width)
@@ -479,7 +479,7 @@ func TestRegressionIssue19(t *testing.T) {
 	rand.Seed(0) // Seed with a value that will reliably not spawn food
 	r := getStandardRuleset(Settings{})
 	for _, test := range tests {
-		_, nextState, err := r.Execute(test.prevState, r.Settings(), test.moves)
+		_, nextState, err := r.Execute(test.prevState, test.moves)
 		require.Equal(t, err, test.expectedError)
 		if test.expectedState != nil {
 			require.Equal(t, test.expectedState.Width, nextState.Width)
@@ -1629,7 +1629,7 @@ func TestIsGameOver(t *testing.T) {
 			Food:   []Point{},
 		}
 
-		actual, _, err := r.Execute(b, r.Settings(), nil)
+		actual, _, err := r.Execute(b, nil)
 		require.NoError(t, err)
 		require.Equal(t, test.Expected, actual)
 	}

--- a/standard_test.go
+++ b/standard_test.go
@@ -1,6 +1,7 @@
 package rules
 
 import (
+	"fmt"
 	"math"
 	"math/rand"
 	"testing"
@@ -1328,7 +1329,7 @@ func TestMaybeDamageHazards(t *testing.T) {
 
 	for _, test := range tests {
 		b := &BoardState{Turn: 41, Snakes: test.Snakes, Hazards: test.Hazards, Food: test.Food}
-		r := NewRulesetBuilder().WithSettings(Settings{HazardDamagePerTurn: 100}).NamedRuleset(GameTypeStandard)
+		r := getStandardRuleset(NewSettingsWithParams(ParamHazardDamagePerTurn, "100"))
 		_, err := DamageHazardsStandard(b, r.Settings(), mockSnakeMoves())
 		require.NoError(t, err)
 
@@ -1372,7 +1373,7 @@ func TestHazardDamagePerTurn(t *testing.T) {
 		if test.Food {
 			b.Food = []Point{{0, 0}}
 		}
-		r := getStandardRuleset(Settings{HazardDamagePerTurn: test.HazardDamagePerTurn})
+		r := getStandardRuleset(NewSettingsWithParams(ParamHazardDamagePerTurn, fmt.Sprint(test.HazardDamagePerTurn)))
 
 		_, err := DamageHazardsStandard(b, r.Settings(), mockSnakeMoves())
 		require.Equal(t, test.Error, err)
@@ -1479,7 +1480,7 @@ func TestMaybeSpawnFoodMinimum(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		r := getStandardRuleset(Settings{MinimumFood: test.MinimumFood})
+		r := getStandardRuleset(NewSettingsWithParams(ParamMinimumFood, fmt.Sprint(test.MinimumFood)))
 		b := &BoardState{
 			Height: 11,
 			Width:  11,
@@ -1497,7 +1498,7 @@ func TestMaybeSpawnFoodMinimum(t *testing.T) {
 }
 
 func TestMaybeSpawnFoodZeroChance(t *testing.T) {
-	r := getStandardRuleset(Settings{FoodSpawnChance: 0})
+	r := getStandardRuleset(NewSettingsWithParams(ParamFoodSpawnChance, "0"))
 	b := &BoardState{
 		Height: 11,
 		Width:  11,
@@ -1515,7 +1516,7 @@ func TestMaybeSpawnFoodZeroChance(t *testing.T) {
 }
 
 func TestMaybeSpawnFoodHundredChance(t *testing.T) {
-	r := getStandardRuleset(Settings{FoodSpawnChance: 100})
+	r := getStandardRuleset(NewSettingsWithParams(ParamFoodSpawnChance, "100"))
 	b := &BoardState{
 		Height: 11,
 		Width:  11,
@@ -1547,7 +1548,7 @@ func TestMaybeSpawnFoodHalfChance(t *testing.T) {
 		{165, []Point{{4, 4}}, 2},
 	}
 
-	r := getStandardRuleset(Settings{FoodSpawnChance: 50})
+	r := getStandardRuleset(NewSettingsWithParams(ParamFoodSpawnChance, "50"))
 	for _, test := range tests {
 		b := &BoardState{
 			Height: 4,

--- a/wrapped.go
+++ b/wrapped.go
@@ -9,22 +9,6 @@ var wrappedRulesetStages = []string{
 	StageEliminationStandard,
 }
 
-type WrappedRuleset struct {
-	StandardRuleset
-}
-
-func (r *WrappedRuleset) Name() string { return GameTypeWrapped }
-
-func (r WrappedRuleset) Execute(bs *BoardState, s Settings, sm []SnakeMove) (bool, *BoardState, error) {
-	return NewPipeline(wrappedRulesetStages...).Execute(bs, s, sm)
-}
-
-func (r *WrappedRuleset) CreateNextBoardState(prevState *BoardState, moves []SnakeMove) (*BoardState, error) {
-	_, nextState, err := r.Execute(prevState, r.Settings(), moves)
-
-	return nextState, err
-}
-
 func MoveSnakesWrapped(b *BoardState, settings Settings, moves []SnakeMove) (bool, error) {
 	if IsInitialization(b, settings, moves) {
 		return false, nil
@@ -45,10 +29,6 @@ func MoveSnakesWrapped(b *BoardState, settings Settings, moves []SnakeMove) (boo
 	}
 
 	return false, nil
-}
-
-func (r *WrappedRuleset) IsGameOver(b *BoardState) (bool, error) {
-	return GameOverStandard(b, r.Settings(), nil)
 }
 
 func wrap(value, min, max int) int {

--- a/wrapped_test.go
+++ b/wrapped_test.go
@@ -32,7 +32,7 @@ func TestLeft(t *testing.T) {
 
 	r := getWrappedRuleset(Settings{})
 
-	gameOver, nextBoardState, err := r.Execute(boardState, r.Settings(), snakeMoves)
+	gameOver, nextBoardState, err := r.Execute(boardState, snakeMoves)
 	require.NoError(t, err)
 	require.False(t, gameOver)
 	require.Equal(t, len(boardState.Snakes), len(nextBoardState.Snakes))
@@ -72,7 +72,7 @@ func TestRight(t *testing.T) {
 
 	r := getWrappedRuleset(Settings{})
 
-	gameOver, nextBoardState, err := r.Execute(boardState, r.Settings(), snakeMoves)
+	gameOver, nextBoardState, err := r.Execute(boardState, snakeMoves)
 	require.NoError(t, err)
 	require.False(t, gameOver)
 	require.Equal(t, len(boardState.Snakes), len(nextBoardState.Snakes))
@@ -112,7 +112,7 @@ func TestUp(t *testing.T) {
 
 	r := getWrappedRuleset(Settings{})
 
-	gameOver, nextBoardState, err := r.Execute(boardState, r.Settings(), snakeMoves)
+	gameOver, nextBoardState, err := r.Execute(boardState, snakeMoves)
 	require.NoError(t, err)
 	require.False(t, gameOver)
 	require.Equal(t, len(boardState.Snakes), len(nextBoardState.Snakes))
@@ -152,7 +152,7 @@ func TestDown(t *testing.T) {
 
 	r := getWrappedRuleset(Settings{})
 
-	gameOver, nextBoardState, err := r.Execute(boardState, r.Settings(), snakeMoves)
+	gameOver, nextBoardState, err := r.Execute(boardState, snakeMoves)
 	require.NoError(t, err)
 	require.False(t, gameOver)
 	require.Equal(t, len(boardState.Snakes), len(nextBoardState.Snakes))
@@ -195,7 +195,7 @@ func TestEdgeCrossingCollision(t *testing.T) {
 
 	r := getWrappedRuleset(Settings{})
 
-	gameOver, nextBoardState, err := r.Execute(boardState, r.Settings(), snakeMoves)
+	gameOver, nextBoardState, err := r.Execute(boardState, snakeMoves)
 	require.NoError(t, err)
 	require.False(t, gameOver)
 	require.Equal(t, len(boardState.Snakes), len(nextBoardState.Snakes))
@@ -239,7 +239,7 @@ func TestEdgeCrossingEating(t *testing.T) {
 
 	r := getWrappedRuleset(Settings{})
 
-	gameOver, nextBoardState, err := r.Execute(boardState, r.Settings(), snakeMoves)
+	gameOver, nextBoardState, err := r.Execute(boardState, snakeMoves)
 	require.NoError(t, err)
 	require.False(t, gameOver)
 	require.Equal(t, len(boardState.Snakes), len(nextBoardState.Snakes))

--- a/wrapped_test.go
+++ b/wrapped_test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func getWrappedRuleset(settings Settings) Ruleset {
+	return NewRulesetBuilder().WithSettings(settings).NamedRuleset(GameTypeWrapped)
+}
+
 func TestLeft(t *testing.T) {
 	boardState := &BoardState{
 		Width:  11,
@@ -26,10 +30,11 @@ func TestLeft(t *testing.T) {
 		{ID: "topRight", Move: "left"},
 	}
 
-	r := WrappedRuleset{}
+	r := getWrappedRuleset(Settings{})
 
-	nextBoardState, err := r.CreateNextBoardState(boardState, snakeMoves)
+	gameOver, nextBoardState, err := r.Execute(boardState, r.Settings(), snakeMoves)
 	require.NoError(t, err)
+	require.False(t, gameOver)
 	require.Equal(t, len(boardState.Snakes), len(nextBoardState.Snakes))
 
 	expectedSnakes := []Snake{
@@ -65,10 +70,11 @@ func TestRight(t *testing.T) {
 		{ID: "topRight", Move: "right"},
 	}
 
-	r := WrappedRuleset{}
+	r := getWrappedRuleset(Settings{})
 
-	nextBoardState, err := r.CreateNextBoardState(boardState, snakeMoves)
+	gameOver, nextBoardState, err := r.Execute(boardState, r.Settings(), snakeMoves)
 	require.NoError(t, err)
+	require.False(t, gameOver)
 	require.Equal(t, len(boardState.Snakes), len(nextBoardState.Snakes))
 
 	expectedSnakes := []Snake{
@@ -104,10 +110,11 @@ func TestUp(t *testing.T) {
 		{ID: "topRight", Move: "up"},
 	}
 
-	r := WrappedRuleset{}
+	r := getWrappedRuleset(Settings{})
 
-	nextBoardState, err := r.CreateNextBoardState(boardState, snakeMoves)
+	gameOver, nextBoardState, err := r.Execute(boardState, r.Settings(), snakeMoves)
 	require.NoError(t, err)
+	require.False(t, gameOver)
 	require.Equal(t, len(boardState.Snakes), len(nextBoardState.Snakes))
 
 	expectedSnakes := []Snake{
@@ -143,10 +150,11 @@ func TestDown(t *testing.T) {
 		{ID: "topRight", Move: "down"},
 	}
 
-	r := WrappedRuleset{}
+	r := getWrappedRuleset(Settings{})
 
-	nextBoardState, err := r.CreateNextBoardState(boardState, snakeMoves)
+	gameOver, nextBoardState, err := r.Execute(boardState, r.Settings(), snakeMoves)
 	require.NoError(t, err)
+	require.False(t, gameOver)
 	require.Equal(t, len(boardState.Snakes), len(nextBoardState.Snakes))
 
 	expectedSnakes := []Snake{
@@ -185,10 +193,11 @@ func TestEdgeCrossingCollision(t *testing.T) {
 		{ID: "rightEdge", Move: "down"},
 	}
 
-	r := WrappedRuleset{}
+	r := getWrappedRuleset(Settings{})
 
-	nextBoardState, err := r.CreateNextBoardState(boardState, snakeMoves)
+	gameOver, nextBoardState, err := r.Execute(boardState, r.Settings(), snakeMoves)
 	require.NoError(t, err)
+	require.False(t, gameOver)
 	require.Equal(t, len(boardState.Snakes), len(nextBoardState.Snakes))
 
 	expectedSnakes := []Snake{
@@ -228,10 +237,11 @@ func TestEdgeCrossingEating(t *testing.T) {
 		{ID: "other", Move: "left"},
 	}
 
-	r := WrappedRuleset{}
+	r := getWrappedRuleset(Settings{})
 
-	nextBoardState, err := r.CreateNextBoardState(boardState, snakeMoves)
+	gameOver, nextBoardState, err := r.Execute(boardState, r.Settings(), snakeMoves)
 	require.NoError(t, err)
+	require.False(t, gameOver)
 	require.Equal(t, len(boardState.Snakes), len(nextBoardState.Snakes))
 
 	expectedSnakes := []Snake{
@@ -330,14 +340,10 @@ func TestWrappedCreateNextBoardState(t *testing.T) {
 		standardMoveAndCollideMAD,
 		wrappedCaseMoveAndWrap,
 	}
-	r := WrappedRuleset{}
-	rb := NewRulesetBuilder().WithParams(map[string]string{
-		ParamGameType: GameTypeWrapped,
-	})
+	r := getWrappedRuleset(Settings{})
 	for _, gc := range cases {
-		gc.requireValidNextState(t, &r)
-		// also test a RulesBuilder constructed instance
-		gc.requireValidNextState(t, rb.Ruleset())
+		// test a RulesBuilder constructed instance
+		gc.requireValidNextState(t, r)
 		// also test a pipeline with the same settings
 		gc.requireValidNextState(t, NewRulesetBuilder().PipelineRuleset(GameTypeWrapped, NewPipeline(wrappedRulesetStages...)))
 	}


### PR DESCRIPTION
Removes and simplifies some of the `Ruleset` and `RulesetBuilder` interfaces, and integrates them into the CLI. This fixes some error handling in the CLI as well.

`Ruleset` now looks like this:
https://github.com/BattlesnakeOfficial/rules/blob/2766ad70f4ff1ccc399539951c0972b922b9cf21/ruleset.go#L3-L13

This is a little less friendly than the old multiple method interface, but I'm planning on adding some helpers in the same release to make it simpler to take a ruleset and run a game one turn at a time.

And `RulesetBuilder` takes an explicit ruleset name through the `NamedRuleset`  to construct one of the standard rulesets.
https://github.com/BattlesnakeOfficial/rules/blob/2766ad70f4ff1ccc399539951c0972b922b9cf21/ruleset.go#L77-L104

`rules.Settings` has also been converted into a generic set of string key-value pairs, with maps and pipeline stages now parsing out settings at runtime. This loses some type safety and adds some redundant parsing, but allows us to add new settings without them being coupled to the API. The standard set of settings exposed through client requests is preserved through `client.RulesetSettings` with a conversion helper.
https://github.com/BattlesnakeOfficial/rules/blob/2766ad70f4ff1ccc399539951c0972b922b9cf21/settings.go