### PR TITLE
Add PreUpdateBoard to GameMap

### DIFF
--- a/cli/commands/play.go
+++ b/cli/commands/play.go
@@ -393,14 +393,19 @@ func (gameState *GameState) createNextBoardState(boardState *rules.BoardState) *
 		moves = append(moves, rules.SnakeMove{ID: snakeState.ID, Move: snakeState.LastMove})
 	}
 
-	boardState, err := gameState.ruleset.CreateNextBoardState(boardState, moves)
+	boardState, err := maps.PreUpdateBoard(gameState.gameMap, boardState, gameState.ruleset.Settings())
+	if err != nil {
+		log.ERROR.Fatalf("Error pre-updating board with game map: %v", err)
+	}
+
+	boardState, err = gameState.ruleset.CreateNextBoardState(boardState, moves)
 	if err != nil {
 		log.ERROR.Fatalf("Error producing next board state: %v", err)
 	}
 
-	boardState, err = maps.UpdateBoard(gameState.gameMap.ID(), boardState, gameState.ruleset.Settings())
+	boardState, err = maps.PostUpdateBoard(gameState.gameMap, boardState, gameState.ruleset.Settings())
 	if err != nil {
-		log.ERROR.Fatalf("Error updating board with game map: %v", err)
+		log.ERROR.Fatalf("Error post-updating board with game map: %v", err)
 	}
 
 	boardState.Turn += 1

--- a/maps/arcade_maze.go
+++ b/maps/arcade_maze.go
@@ -71,7 +71,11 @@ func (m ArcadeMazeMap) SetupBoard(initialBoardState *rules.BoardState, settings 
 	return nil
 }
 
-func (m ArcadeMazeMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+func (m ArcadeMazeMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m ArcadeMazeMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	rand := settings.GetRand(lastBoardState.Turn)
 
 	// Respect FoodSpawnChance setting

--- a/maps/castle_wall.go
+++ b/maps/castle_wall.go
@@ -136,7 +136,11 @@ func (m CastleWallMediumHazardsMap) SetupBoard(initialBoardState *rules.BoardSta
 	return setupCastleWallBoard(m.Meta().MaxPlayers, startPositions, castleWallMediumHazards, initialBoardState, settings, editor)
 }
 
-func (m CastleWallMediumHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+func (m CastleWallMediumHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m CastleWallMediumHazardsMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	maxFood := 2
 	return updateCastleWallBoard(maxFood, castleWallMediumFood, lastBoardState, settings, editor)
 }
@@ -228,7 +232,11 @@ func (m CastleWallLargeHazardsMap) SetupBoard(initialBoardState *rules.BoardStat
 	return setupCastleWallBoard(m.Meta().MaxPlayers, startPositions, castleWallLargeHazards, initialBoardState, settings, editor)
 }
 
-func (m CastleWallLargeHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+func (m CastleWallLargeHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m CastleWallLargeHazardsMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	maxFood := 2
 	return updateCastleWallBoard(maxFood, castleWallLargeFood, lastBoardState, settings, editor)
 }
@@ -420,7 +428,11 @@ func (m CastleWallExtraLargeHazardsMap) SetupBoard(initialBoardState *rules.Boar
 	return setupCastleWallBoard(m.Meta().MaxPlayers, startPositions, castleWallExtraLargeHazards, initialBoardState, settings, editor)
 }
 
-func (m CastleWallExtraLargeHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+func (m CastleWallExtraLargeHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m CastleWallExtraLargeHazardsMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	maxFood := 4
 	return updateCastleWallBoard(maxFood, castleWallExtraLargeFood, lastBoardState, settings, editor)
 }

--- a/maps/empty.go
+++ b/maps/empty.go
@@ -53,6 +53,10 @@ func (m EmptyMap) SetupBoard(initialBoardState *rules.BoardState, settings rules
 	return nil
 }
 
-func (m EmptyMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+func (m EmptyMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m EmptyMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	return nil
 }

--- a/maps/empty_test.go
+++ b/maps/empty_test.go
@@ -152,7 +152,7 @@ func TestEmptyMapUpdateBoard(t *testing.T) {
 	}.WithRand(rules.MaxRand)
 	nextBoardState := initialBoardState.Clone()
 
-	err := m.UpdateBoard(initialBoardState.Clone(), settings, maps.NewBoardStateEditor(nextBoardState))
+	err := m.PostUpdateBoard(initialBoardState.Clone(), settings, maps.NewBoardStateEditor(nextBoardState))
 
 	require.NoError(t, err)
 	require.Equal(t, &rules.BoardState{

--- a/maps/game_map.go
+++ b/maps/game_map.go
@@ -24,19 +24,20 @@ type GameMap interface {
 	// Called to generate a new board. The map is responsible for placing all snakes, food, and hazards.
 	SetupBoard(initialBoardState *rules.BoardState, settings rules.Settings, editor Editor) error
 
-	// Called every turn to optionally update the board.
-	// This is called before the board is sent to snakes to get their moves, so changes made here
-	// will be seen by snakes before before making their moves, but users in the browser will see
-	// the changes at the same time as the snakes' moves.
+	// Called every turn to optionally update the board before the board is sent to snakes to get their moves.
+	// Changes made here will be seen by snakes before before making their moves, but users in the
+	// browser will see the changes at the same time as the snakes' moves.
 	//
-	// Disclaimer: Unless you have a specific usecase like moving hazards, PostUpdateBoard is probably the
-	// better function to use.
+	// State that is stored in the map by this method will be visible to the PostUpdateBoard method
+	// later in the same turn, but will not nessecarily be available when processing later turns.
+	//
+	// Disclaimer: Unless you have a specific usecase like moving hazards or storing intermediate state,
+	// PostUpdateBoard is probably the better function to use.
 	PreUpdateBoard(previousBoardState *rules.BoardState, settings rules.Settings, editor Editor) error
 
-	// Called every turn to optionally update the board.
-	// This is called after snakes have made their moves and all rules have been applied.
-	// That means that both snakes, as well as users in the browser will see the changes made here
-	// before the snakes make their next moves.
+	// Called every turn to optionally update the board after all other rules have been applied.
+	// Changes made here will be seen by both snakes and users in the browser, before before snakes
+	// make their next moves.
 	PostUpdateBoard(previousBoardState *rules.BoardState, settings rules.Settings, editor Editor) error
 }
 

--- a/maps/game_map.go
+++ b/maps/game_map.go
@@ -25,7 +25,19 @@ type GameMap interface {
 	SetupBoard(initialBoardState *rules.BoardState, settings rules.Settings, editor Editor) error
 
 	// Called every turn to optionally update the board.
-	UpdateBoard(previousBoardState *rules.BoardState, settings rules.Settings, editor Editor) error
+	// This is called before the board is sent to snakes to get their moves, so changes made here
+	// will be seen by snakes before before making their moves, but users in the browser will see
+	// the changes at the same time as the snakes' moves.
+	//
+	// Disclaimer: Unless you have a specific usecase like moving hazards, PostUpdateBoard is probably the
+	// better function to use.
+	PreUpdateBoard(previousBoardState *rules.BoardState, settings rules.Settings, editor Editor) error
+
+	// Called every turn to optionally update the board.
+	// This is called after snakes have made their moves and all rules have been applied.
+	// That means that both snakes, as well as users in the browser will see the changes made here
+	// before the snakes make their next moves.
+	PostUpdateBoard(previousBoardState *rules.BoardState, settings rules.Settings, editor Editor) error
 }
 
 type Metadata struct {

--- a/maps/hazard_pits.go
+++ b/maps/hazard_pits.go
@@ -97,8 +97,12 @@ func (m HazardPitsMap) SetupBoard(initialBoardState *rules.BoardState, settings 
 	return nil
 }
 
-func (m HazardPitsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-	err := StandardMap{}.UpdateBoard(lastBoardState, settings, editor)
+func (m HazardPitsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m HazardPitsMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	err := StandardMap{}.PostUpdateBoard(lastBoardState, settings, editor)
 	if err != nil {
 		return err
 	}

--- a/maps/hazard_pits_test.go
+++ b/maps/hazard_pits_test.go
@@ -47,7 +47,7 @@ func TestHazardPitsMap(t *testing.T) {
 	// Verify the hazard progression through the turns
 	for i := 0; i < 16; i++ {
 		state.Turn = i
-		err = m.UpdateBoard(state, settings, editor)
+		err = m.PostUpdateBoard(state, settings, editor)
 		require.NoError(t, err)
 		if i == 1 {
 			require.Len(t, state.Hazards, 21)

--- a/maps/hazards.go
+++ b/maps/hazards.go
@@ -54,8 +54,12 @@ func (m InnerBorderHazardsMap) SetupBoard(lastBoardState *rules.BoardState, sett
 	return nil
 }
 
-func (m InnerBorderHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-	return StandardMap{}.UpdateBoard(lastBoardState, settings, editor)
+func (m InnerBorderHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m InnerBorderHazardsMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return StandardMap{}.PostUpdateBoard(lastBoardState, settings, editor)
 }
 
 type ConcentricRingsHazardsMap struct{}
@@ -96,8 +100,12 @@ func (m ConcentricRingsHazardsMap) SetupBoard(lastBoardState *rules.BoardState, 
 	return nil
 }
 
-func (m ConcentricRingsHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-	return StandardMap{}.UpdateBoard(lastBoardState, settings, editor)
+func (m ConcentricRingsHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m ConcentricRingsHazardsMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return StandardMap{}.PostUpdateBoard(lastBoardState, settings, editor)
 }
 
 type ColumnsHazardsMap struct{}
@@ -135,8 +143,12 @@ func (m ColumnsHazardsMap) SetupBoard(lastBoardState *rules.BoardState, settings
 	return nil
 }
 
-func (m ColumnsHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-	return StandardMap{}.UpdateBoard(lastBoardState, settings, editor)
+func (m ColumnsHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m ColumnsHazardsMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return StandardMap{}.PostUpdateBoard(lastBoardState, settings, editor)
 }
 
 type SpiralHazardsMap struct{}
@@ -163,8 +175,12 @@ func (m SpiralHazardsMap) SetupBoard(lastBoardState *rules.BoardState, settings 
 	return (StandardMap{}).SetupBoard(lastBoardState, settings, editor)
 }
 
-func (m SpiralHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-	err := StandardMap{}.UpdateBoard(lastBoardState, settings, editor)
+func (m SpiralHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m SpiralHazardsMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	err := StandardMap{}.PostUpdateBoard(lastBoardState, settings, editor)
 	if err != nil {
 		return err
 	}
@@ -256,8 +272,12 @@ func (m ScatterFillMap) SetupBoard(lastBoardState *rules.BoardState, settings ru
 	return (StandardMap{}).SetupBoard(lastBoardState, settings, editor)
 }
 
-func (m ScatterFillMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-	err := StandardMap{}.UpdateBoard(lastBoardState, settings, editor)
+func (m ScatterFillMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m ScatterFillMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	err := StandardMap{}.PostUpdateBoard(lastBoardState, settings, editor)
 	if err != nil {
 		return err
 	}
@@ -308,8 +328,12 @@ func (m DirectionalExpandingBoxMap) SetupBoard(lastBoardState *rules.BoardState,
 	return (StandardMap{}).SetupBoard(lastBoardState, settings, editor)
 }
 
-func (m DirectionalExpandingBoxMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-	err := StandardMap{}.UpdateBoard(lastBoardState, settings, editor)
+func (m DirectionalExpandingBoxMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m DirectionalExpandingBoxMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	err := StandardMap{}.PostUpdateBoard(lastBoardState, settings, editor)
 	if err != nil {
 		return err
 	}
@@ -423,8 +447,12 @@ func (m ExpandingBoxMap) SetupBoard(lastBoardState *rules.BoardState, settings r
 	return (StandardMap{}).SetupBoard(lastBoardState, settings, editor)
 }
 
-func (m ExpandingBoxMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-	err := StandardMap{}.UpdateBoard(lastBoardState, settings, editor)
+func (m ExpandingBoxMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m ExpandingBoxMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	err := StandardMap{}.PostUpdateBoard(lastBoardState, settings, editor)
 	if err != nil {
 		return err
 	}
@@ -499,8 +527,12 @@ func (m ExpandingScatterMap) SetupBoard(lastBoardState *rules.BoardState, settin
 	return (StandardMap{}).SetupBoard(lastBoardState, settings, editor)
 }
 
-func (m ExpandingScatterMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-	err := StandardMap{}.UpdateBoard(lastBoardState, settings, editor)
+func (m ExpandingScatterMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return (StandardMap{}).PreUpdateBoard(lastBoardState, settings, editor)
+}
+
+func (m ExpandingScatterMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	err := StandardMap{}.PostUpdateBoard(lastBoardState, settings, editor)
 	if err != nil {
 		return err
 	}

--- a/maps/hazards_test.go
+++ b/maps/hazards_test.go
@@ -102,7 +102,7 @@ func TestSpiralHazardsMap(t *testing.T) {
 
 	for i := 0; i < 1000; i++ {
 		state.Turn = i
-		err = m.UpdateBoard(state, settings, editor)
+		err = m.PostUpdateBoard(state, settings, editor)
 		require.NoError(t, err)
 	}
 	require.NotEmpty(t, state.Hazards)
@@ -123,7 +123,7 @@ func TestScatterFillMap(t *testing.T) {
 	totalTurns := 11 * 11 * 2
 	for i := 0; i < totalTurns; i++ {
 		state.Turn = i
-		err = m.UpdateBoard(state, settings, editor)
+		err = m.PostUpdateBoard(state, settings, editor)
 		require.NoError(t, err)
 	}
 	require.NotEmpty(t, state.Hazards)
@@ -144,7 +144,7 @@ func TestDirectionalExpandingBoxMap(t *testing.T) {
 	totalTurns := 1000
 	for i := 0; i < totalTurns; i++ {
 		state.Turn = i
-		err = m.UpdateBoard(state, settings, editor)
+		err = m.PostUpdateBoard(state, settings, editor)
 		require.NoError(t, err)
 	}
 	require.NotEmpty(t, state.Hazards)
@@ -165,7 +165,7 @@ func TestExpandingBoxMap(t *testing.T) {
 	totalTurns := 1000
 	for i := 0; i < totalTurns; i++ {
 		state.Turn = i
-		err = m.UpdateBoard(state, settings, editor)
+		err = m.PostUpdateBoard(state, settings, editor)
 		require.NoError(t, err)
 	}
 	require.NotEmpty(t, state.Hazards)
@@ -186,7 +186,7 @@ func TestExpandingScatterMap(t *testing.T) {
 	totalTurns := 1000
 	for i := 0; i < totalTurns; i++ {
 		state.Turn = i
-		err = m.UpdateBoard(state, settings, editor)
+		err = m.PostUpdateBoard(state, settings, editor)
 		require.NoError(t, err)
 	}
 	require.NotEmpty(t, state.Hazards)

--- a/maps/healing_pools.go
+++ b/maps/healing_pools.go
@@ -50,8 +50,12 @@ func (m HealingPoolsMap) SetupBoard(initialBoardState *rules.BoardState, setting
 	return nil
 }
 
-func (m HealingPoolsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-	if err := (StandardMap{}).UpdateBoard(lastBoardState, settings, editor); err != nil {
+func (m HealingPoolsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m HealingPoolsMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	if err := (StandardMap{}).PostUpdateBoard(lastBoardState, settings, editor); err != nil {
 		return err
 	}
 

--- a/maps/healing_pools_test.go
+++ b/maps/healing_pools_test.go
@@ -59,7 +59,7 @@ func TestHealingPoolsMap(t *testing.T) {
 			totalTurns := settings.RoyaleSettings.ShrinkEveryNTurns*tc.expectedHazards + 1
 			for i := 0; i < totalTurns; i++ {
 				state.Turn = i
-				err = m.UpdateBoard(state, settings, editor)
+				err = m.PostUpdateBoard(state, settings, editor)
 				require.NoError(t, err)
 			}
 

--- a/maps/helpers.go
+++ b/maps/helpers.go
@@ -25,23 +25,48 @@ func SetupBoard(mapID string, settings rules.Settings, width, height int, snakeI
 	return boardState, nil
 }
 
-//  UpdateBoard is a shortcut for looking up a map by ID and updating an existing board state with it.
-func UpdateBoard(mapID string, previousBoardState *rules.BoardState, settings rules.Settings) (*rules.BoardState, error) {
-	gameMap, err := GetMap(mapID)
-	if err != nil {
-		return nil, err
-	}
-
+// PreUpdateBoard updates a board state with a map.
+func PreUpdateBoard(gameMap GameMap, previousBoardState *rules.BoardState, settings rules.Settings) (*rules.BoardState, error) {
 	nextBoardState := previousBoardState.Clone()
 	editor := NewBoardStateEditor(nextBoardState)
 
-	err = gameMap.UpdateBoard(previousBoardState, settings, editor)
+	err := gameMap.PreUpdateBoard(previousBoardState, settings, editor)
 	if err != nil {
 		return nil, err
 	}
 
 	return nextBoardState, nil
 }
+
+func PostUpdateBoard(gameMap GameMap, previousBoardState *rules.BoardState, settings rules.Settings) (*rules.BoardState, error) {
+	nextBoardState := previousBoardState.Clone()
+	editor := NewBoardStateEditor(nextBoardState)
+
+	err := gameMap.PostUpdateBoard(previousBoardState, settings, editor)
+	if err != nil {
+		return nil, err
+	}
+
+	return nextBoardState, nil
+}
+
+// // PostUpdateBoard is a shortcut for looking up a map by ID and updating an existing board state with it.
+// func PostUpdateBoard(mapID string, previousBoardState *rules.BoardState, settings rules.Settings) (*rules.BoardState, error) {
+// 	gameMap, err := GetMap(mapID)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	nextBoardState := previousBoardState.Clone()
+// 	editor := NewBoardStateEditor(nextBoardState)
+
+// 	err = gameMap.PostUpdateBoard(previousBoardState, settings, editor)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+
+// 	return nextBoardState, nil
+// }
 
 // An implementation of GameMap that just does predetermined placements, for testing.
 type StubMap struct {
@@ -77,7 +102,11 @@ func (m StubMap) SetupBoard(initialBoardState *rules.BoardState, settings rules.
 	return nil
 }
 
-func (m StubMap) UpdateBoard(previousBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+func (m StubMap) PreUpdateBoard(previousBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m StubMap) PostUpdateBoard(previousBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	if m.Error != nil {
 		return m.Error
 	}

--- a/maps/helpers_test.go
+++ b/maps/helpers_test.go
@@ -100,7 +100,7 @@ func TestUpdateBoard(t *testing.T) {
 	}
 
 	maps.TestMap(testMap.ID(), testMap, func() {
-		boardState, err := maps.UpdateBoard(testMap.ID(), previousBoardState, rules.Settings{})
+		boardState, err := maps.PostUpdateBoard(testMap.ID(), previousBoardState, rules.Settings{})
 
 		require.NoError(t, err)
 

--- a/maps/registry_test.go
+++ b/maps/registry_test.go
@@ -96,7 +96,7 @@ func TestRegisteredMaps(t *testing.T) {
 
 			passedBoardState := previousBoardState.Clone()
 			tempBoardState := previousBoardState.Clone()
-			err := gameMap.UpdateBoard(passedBoardState, testSettings, NewBoardStateEditor(tempBoardState))
+			err := gameMap.PostUpdateBoard(passedBoardState, testSettings, NewBoardStateEditor(tempBoardState))
 			require.NoError(t, err, "GameMap.UpdateBoard returned an error")
 			require.Equal(t, previousBoardState, passedBoardState, "BoardState should not be modified directly by GameMap.UpdateBoard")
 		})

--- a/maps/rivers_and_bridges.go
+++ b/maps/rivers_and_bridges.go
@@ -71,7 +71,11 @@ func (m RiverAndBridgesMediumHazardsMap) SetupBoard(initialBoardState *rules.Boa
 	return setupRiverAndBridgesBoard(riversAndBridgesMediumStartPositions, riversAndBridgesMediumHazards, initialBoardState, settings, editor)
 }
 
-func (m RiverAndBridgesMediumHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+func (m RiverAndBridgesMediumHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m RiverAndBridgesMediumHazardsMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	return placeRiverAndBridgesFood(lastBoardState, settings, editor)
 }
 
@@ -142,7 +146,11 @@ func (m RiverAndBridgesLargeHazardsMap) SetupBoard(initialBoardState *rules.Boar
 	return setupRiverAndBridgesBoard(riversAndBridgesLargeStartPositions, riversAndBridgesLargeHazards, initialBoardState, settings, editor)
 }
 
-func (m RiverAndBridgesLargeHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+func (m RiverAndBridgesLargeHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m RiverAndBridgesLargeHazardsMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	return placeRiverAndBridgesFood(lastBoardState, settings, editor)
 }
 
@@ -241,7 +249,11 @@ func (m RiverAndBridgesExtraLargeHazardsMap) SetupBoard(initialBoardState *rules
 	return setupRiverAndBridgesBoard(riversAndBridgesExtraLargeStartPositions, riversAndBridgesExtraLargeHazards, initialBoardState, settings, editor)
 }
 
-func (m RiverAndBridgesExtraLargeHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+func (m RiverAndBridgesExtraLargeHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m RiverAndBridgesExtraLargeHazardsMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	return placeRiverAndBridgesFood(lastBoardState, settings, editor)
 }
 
@@ -355,7 +367,11 @@ func (m IslandsAndBridgesMediumHazardsMap) SetupBoard(initialBoardState *rules.B
 	return setupRiverAndBridgesBoard(islandsAndBridgesMediumStartPositions, islandsAndBridgesMediumHazards, initialBoardState, settings, editor)
 }
 
-func (m IslandsAndBridgesMediumHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+func (m IslandsAndBridgesMediumHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m IslandsAndBridgesMediumHazardsMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	return placeRiverAndBridgesFood(lastBoardState, settings, editor)
 }
 
@@ -441,7 +457,11 @@ func (m IslandsAndBridgesLargeHazardsMap) SetupBoard(initialBoardState *rules.Bo
 	return setupRiverAndBridgesBoard(islandsAndBridgesLargeStartPositions, islandsAndBridgesLargeHazards, initialBoardState, settings, editor)
 }
 
-func (m IslandsAndBridgesLargeHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+func (m IslandsAndBridgesLargeHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m IslandsAndBridgesLargeHazardsMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	return placeRiverAndBridgesFood(lastBoardState, settings, editor)
 }
 

--- a/maps/royale.go
+++ b/maps/royale.go
@@ -33,9 +33,13 @@ func (m RoyaleHazardsMap) SetupBoard(lastBoardState *rules.BoardState, settings 
 	return StandardMap{}.SetupBoard(lastBoardState, settings, editor)
 }
 
-func (m RoyaleHazardsMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+func (m RoyaleHazardsMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m RoyaleHazardsMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	// Use StandardMap to populate food
-	if err := (StandardMap{}).UpdateBoard(lastBoardState, settings, editor); err != nil {
+	if err := (StandardMap{}).PostUpdateBoard(lastBoardState, settings, editor); err != nil {
 		return err
 	}
 

--- a/maps/sinkholes.go
+++ b/maps/sinkholes.go
@@ -33,8 +33,12 @@ func (m SinkholesMap) SetupBoard(initialBoardState *rules.BoardState, settings r
 	return (StandardMap{}).SetupBoard(initialBoardState, settings, editor)
 }
 
-func (m SinkholesMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-	err := StandardMap{}.UpdateBoard(lastBoardState, settings, editor)
+func (m SinkholesMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m SinkholesMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	err := StandardMap{}.PostUpdateBoard(lastBoardState, settings, editor)
 	if err != nil {
 		return err
 	}

--- a/maps/sinkholes_test.go
+++ b/maps/sinkholes_test.go
@@ -38,7 +38,7 @@ func TestSinkholesMap(t *testing.T) {
 			totalTurns := 100
 			for i := 0; i < totalTurns; i++ {
 				state.Turn = i
-				err = m.UpdateBoard(state, settings, editor)
+				err = m.PostUpdateBoard(state, settings, editor)
 				require.NoError(t, err)
 			}
 			require.NotEmpty(t, state.Hazards)

--- a/maps/snail_mode.go
+++ b/maps/snail_mode.go
@@ -4,20 +4,22 @@ import (
 	"github.com/BattlesnakeOfficial/rules"
 )
 
-type SnailModeMap struct{}
+type SnailModeMap struct{
+	lastTailPositions map[rules.Point]int // local state is preserved during the turn
+}
 
 // init registers this map in the global registry.
 func init() {
-	globalRegistry.RegisterMap("snail_mode", SnailModeMap{})
+	globalRegistry.RegisterMap("snail_mode", &SnailModeMap{lastTailPositions: nil})
 }
 
 // ID returns a unique identifier for this map.
-func (m SnailModeMap) ID() string {
+func (m *SnailModeMap) ID() string {
 	return "snail_mode"
 }
 
 // Meta returns the non-functional metadata about this map.
-func (m SnailModeMap) Meta() Metadata {
+func (m *SnailModeMap) Meta() Metadata {
 	return Metadata{
 		Name:        "Snail Mode",
 		Description: "Snakes leave behind a trail of hazards",
@@ -31,7 +33,7 @@ func (m SnailModeMap) Meta() Metadata {
 }
 
 // SetupBoard here is pretty 'standard' and doesn't do any special setup for this game mode
-func (m SnailModeMap) SetupBoard(initialBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+func (m *SnailModeMap) SetupBoard(initialBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	rand := settings.GetRand(0)
 
 	if len(initialBoardState.Snakes) > int(m.Meta().MaxPlayers) {
@@ -86,12 +88,28 @@ func isEliminated(s *rules.Snake) bool {
 	return s.EliminatedCause != rules.NotEliminated
 }
 
-// UpdateBoard does the work of placing the hazards along the 'snail tail' of snakes
-// This is responsible for saving the current tail location off the board
-// and restoring the previous tail position. This also handles removing one hazards from
-// the current stacks so the hazards tails fade as the snake moves away.
-func (m SnailModeMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
-	err := StandardMap{}.UpdateBoard(lastBoardState, settings, editor)
+// PreUpdateBoard stores the tail position of each snake in memory, to be
+// able to place hazards there after the snakes move.
+func (m *SnailModeMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	m.lastTailPositions = make(map[rules.Point]int)
+	for _, snake := range lastBoardState.Snakes {
+		if isEliminated(&snake) {
+			continue
+		}
+		// Double tail means that the tail will stay on the same square for more
+		// than one turn, so we don't want to spawn hazards
+		if doubleTail(&snake) {
+			continue
+		}
+		m.lastTailPositions[snake.Body[len(snake.Body)-1]] = len(snake.Body)
+	}
+	return nil
+}
+
+// PostUpdateBoard does the work of placing the hazards along the 'snail tail' of snakes
+// This also handles removing one hazards from the current stacks so the hazards tails fade as the snake moves away.
+func (m *SnailModeMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	err := StandardMap{}.PostUpdateBoard(lastBoardState, settings, editor)
 	if err != nil {
 		return err
 	}
@@ -100,79 +118,38 @@ func (m SnailModeMap) UpdateBoard(lastBoardState *rules.BoardState, settings rul
 	// need to be cleared first.
 	editor.ClearHazards()
 
-	// This is a list of all the hazards we want to add for the previous tails
-	// These were stored off board in the previous turn as a way to save state
-	// When we add the locations to this list we have already converted the off-board
-	// points to on-board points
-	tailLocations := make([]rules.Point, 0, len(lastBoardState.Snakes))
-
 	// Count the number of hazards for a given position
-	// Add non-double tail locations to a slice
 	hazardCounts := map[rules.Point]int{}
 	for _, hazard := range lastBoardState.Hazards {
-
-		// discard out of bound
-		if outOfBounds(hazard, lastBoardState.Width, lastBoardState.Height) {
-			onBoardTail := getPrevTailLocation(hazard, lastBoardState.Height)
-			tailLocations = append(tailLocations, onBoardTail)
-		} else {
-			hazardCounts[hazard]++
-		}
+		hazardCounts[hazard]++
 	}
 
 	// Add back existing hazards, but with a stack of 1 less than before.
 	// This has the effect of making the snail-trail disappear over time.
 	for hazard, count := range hazardCounts {
-
 		for i := 0; i < count-1; i++ {
 			editor.AddHazard(hazard)
 		}
 	}
 
-	// Store a stack of hazards for the tail of each snake.  This is stored out
-	// of bounds and then applied on the next turn.  The stack count is equal
-	// the lenght of the snake.
-	for _, snake := range lastBoardState.Snakes {
-		if isEliminated(&snake) {
-			continue
-		}
-
-		// Double tail means that the tail will stay on the same square for more
-		// than one turn, so we don't want to spawn hazards
-		if doubleTail(&snake) {
-			continue
-		}
-
-		tail := snake.Body[len(snake.Body)-1]
-		offBoardTail := storeTailLocation(tail, lastBoardState.Height)
-		for i := 0; i < len(snake.Body); i++ {
-			editor.AddHazard(offBoardTail)
-		}
-	}
-
-	// Read offboard tails and move them to the board. The offboard tails are
-	// stacked based on the length of the snake
-	for _, p := range tailLocations {
-
-		// Skip position if a snakes head occupies it.
-		// Otherwise hazard shows up in the viewer on top of a snake head, but
-		// does not damage the snake, which is visually confusing.
-		isHead := false
+	// Place a new stack of hazards where each snake's tail used to be
+NewHazardLoop:
+	for location, count := range m.lastTailPositions {
 		for _, snake := range lastBoardState.Snakes {
 			if isEliminated(&snake) {
 				continue
 			}
 			head := snake.Body[0]
-			if p.X == head.X && p.Y == head.Y {
-				isHead = true
-				break
+			if location.X == head.X && location.Y == head.Y {
+				// Skip position if a snakes head occupies it.
+				// Otherwise hazard shows up in the viewer on top of a snake head, but
+				// does not damage the snake, which is visually confusing.
+				continue NewHazardLoop
 			}
 		}
-		if isHead {
-			continue
+		for i := 0; i < count; i++  {
+			editor.AddHazard(location)
 		}
-
-		editor.AddHazard(p)
 	}
 
 	return nil

--- a/maps/solo_maze.go
+++ b/maps/solo_maze.go
@@ -176,7 +176,11 @@ func (m SoloMazeMap) PlaceFood(boardState *rules.BoardState, settings rules.Sett
 	}
 }
 
-func (m SoloMazeMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+func (m SoloMazeMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m SoloMazeMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	currentLevel, e := m.ReadBitState(lastBoardState)
 	if e != nil {
 		return e

--- a/maps/standard.go
+++ b/maps/standard.go
@@ -57,7 +57,11 @@ func (m StandardMap) SetupBoard(initialBoardState *rules.BoardState, settings ru
 	return nil
 }
 
-func (m StandardMap) UpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+func (m StandardMap) PreUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
+	return nil
+}
+
+func (m StandardMap) PostUpdateBoard(lastBoardState *rules.BoardState, settings rules.Settings, editor Editor) error {
 	rand := settings.GetRand(lastBoardState.Turn)
 
 	foodNeeded := checkFoodNeedingPlacement(rand, settings, lastBoardState)

--- a/maps/standard_test.go
+++ b/maps/standard_test.go
@@ -306,7 +306,7 @@ func TestStandardMapUpdateBoard(t *testing.T) {
 			settings := test.settings.WithRand(test.rand)
 			editor := maps.NewBoardStateEditor(nextBoardState)
 
-			err := m.UpdateBoard(test.initialBoardState.Clone(), settings, editor)
+			err := m.PostUpdateBoard(test.initialBoardState.Clone(), settings, editor)
 
 			require.NoError(t, err)
 			require.Equal(t, test.expected, nextBoardState)


### PR DESCRIPTION
This is a second, slightly more polished attempt at the PreUpdateBoard extension for the GameMap interface.
It implements the proposed changes from [this discussion](https://github.com/BattlesnakeOfficial/feedback/discussions/211) as closely as possible.

I have also included a refactoring of the snail_mode map that does not use off-board hazards, to demonstrate one of the benefits we gain from these changes.

If you think something is missing or could be better, let me know :)

Co-authored-by: coreyja [coreyja@gmail.com](mailto:coreyja@gmail.com)