### PR TITLE
README.md modified

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -9,12 +9,12 @@ Download precompiled binaries here: <br>
 
 Install as a Go package. Requires Go 1.18 or higher. [[Download](https://golang.org/dl/)]
 ```
-go get github.com/BattlesnakeOfficial/rules/cli/battlesnake
+go install github.com/BattlesnakeOfficial/rules/cli/battlesnake@latest
 ```
 
 Compile from source. Also requires Go 1.18 or higher.
 ```
-git clone git@github.com:BattlesnakeOfficial/rules.git
+git clone https://github.com/BattlesnakeOfficial/rules.git
 cd rules
 go build -o battlesnake ./cli/battlesnake/main.go
 ```


### PR DESCRIPTION
After the go 1.17 update the "go get" command is deprecated "go install" is being used instead. and the URL of the git repository was wrong.
![Screenshot (10)](https://user-images.githubusercontent.com/95410164/207602703-09b2d29f-0299-4f75-8eb2-e0543aafdd8c.png)
